### PR TITLE
Cli options parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,10 @@ See [`docs/architecture.md`](docs/architecture.md) for detailed architectural do
 - [`docs/features/signal-handling.md`](docs/features/signal-handling.md) — OS signal handling (SIGINT/SIGTERM) triggering clean shutdown via ForceQuit
 - [`docs/features/file-logging.md`](docs/features/file-logging.md) — Concurrent-safe timestamped file logger with buffered I/O
 
+## ADRs
+
+- [`docs/adr/20260409135303-cobra-cli-framework.md`](docs/adr/20260409135303-cobra-cli-framework.md) — Decision to use spf13/cobra for CLI argument parsing (POSIX flags, subcommands). Apply when modifying CLI argument handling or adding new commands.
+
 ## Coding Standards
 
 - [`docs/coding-standards/api-design.md`](docs/coding-standards/api-design.md) — API design patterns including unused parameter documentation, bounds guards, precondition validation, and adapter types. Apply when designing or modifying public interfaces and exported functions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,11 +45,11 @@ The Go TUI orchestrator lives in `ralph-tui/`, using [Glyph](https://useglyph.sh
 ```bash
 # Using make (recommended):
 make build
-./bin/ralph-tui <iterations>
+./bin/ralph-tui [-n <iterations>] [-p <project-dir>]
 
 # Or build directly:
 cd ralph-tui && go build -o ../ralph-tui ./cmd/ralph-tui
-./ralph-tui <iterations> [-project-dir <path>]
+./ralph-tui [-n <iterations>] [-p <project-dir>]
 ```
 
 Use `go build` — `go run` won't work because `projectDir` is resolved via `os.Executable()`.
@@ -59,7 +59,7 @@ See [`docs/architecture.md`](docs/architecture.md) for detailed architectural do
 ## Architecture & Feature Documentation
 
 - [`docs/architecture.md`](docs/architecture.md) — System-level architecture overview with block diagrams, data flow, keyboard state machine, and package dependency graph
-- [`docs/features/cli-configuration.md`](docs/features/cli-configuration.md) — CLI argument parsing, flag reordering, and project directory resolution from the executable path
+- [`docs/features/cli-configuration.md`](docs/features/cli-configuration.md) — CLI argument parsing with cobra flags (`--iterations`/`-n`, `--project-dir`/`-p`) and project directory resolution from the executable path
 - [`docs/features/step-definitions.md`](docs/features/step-definitions.md) — JSON step configuration loading and prompt building with variable prepending for iteration context
 - [`docs/features/subprocess-execution.md`](docs/features/subprocess-execution.md) — Subprocess lifecycle management with real-time io.Pipe streaming, graceful SIGTERM/SIGKILL termination, and output capture
 - [`docs/features/workflow-orchestration.md`](docs/features/workflow-orchestration.md) — The Run loop driving iterations and finalization, and the Orchestrate step sequencer with interactive error recovery
@@ -77,7 +77,7 @@ See [`docs/architecture.md`](docs/architecture.md) for detailed architectural do
 - [`docs/coding-standards/api-design.md`](docs/coding-standards/api-design.md) — API design patterns including unused parameter documentation, bounds guards, precondition validation, and adapter types. Apply when designing or modifying public interfaces and exported functions.
 - [`docs/coding-standards/concurrency.md`](docs/coding-standards/concurrency.md) — Concurrency patterns including snapshot-then-unlock, WaitGroup drain, mutex-protected writes, and non-blocking channel sends. Apply when working with goroutines, mutexes, channels, or any shared state.
 - [`docs/coding-standards/error-handling.md`](docs/coding-standards/error-handling.md) — Error handling conventions including package-prefixed messages, file paths in I/O errors, and scanner error checking. Apply to all error creation, wrapping, and propagation.
-- [`docs/coding-standards/go-patterns.md`](docs/coding-standards/go-patterns.md) — Go-specific patterns including flag reordering, symlink-safe path resolution, and 256KB scanner buffers. Apply when working with CLI args, file paths, or subprocess I/O.
+- [`docs/coding-standards/go-patterns.md`](docs/coding-standards/go-patterns.md) — Go-specific patterns including symlink-safe path resolution and 256KB scanner buffers. Apply when working with CLI args, file paths, or subprocess I/O.
 - [`docs/coding-standards/testing.md`](docs/coding-standards/testing.md) — Testing standards including race detector requirement, closeable idempotency tests, input immutability tests, and test helper path resolution. Apply when writing or modifying any test code.
 
 ## How-To Guides

--- a/README.md
+++ b/README.md
@@ -30,27 +30,35 @@ make build
 From the **target repo** (the repo where you want Ralph to work):
 
 ```bash
-# Run 3 iterations
-path/to/pr9k/bin/ralph-tui 3
+# Run until no issues remain (until-done mode)
+path/to/pr9k/bin/ralph-tui
+
+# Or cap at 3 iterations
+path/to/pr9k/bin/ralph-tui -n 3
 ```
 
-Ralph will find the next open issue labeled `ralph`, implement the feature, write tests, run a code review, fix review findings, close the issue, update docs, and push — then repeat for the next issue.
+Ralph will find the next open issue labeled `ralph`, implement the feature, write tests, run a code review, fix review findings, close the issue, update docs, and push — then repeat for the next issue. When run without `-n`, Ralph keeps going until `get_next_issue` finds no more issues.
 
 ## How To
 
 ### Run the orchestrator
 
 ```bash
-# From your target repo:
-path/to/pr9k/bin/ralph-tui <iterations>
+# From your target repo — run until no issues remain:
+path/to/pr9k/bin/ralph-tui
 
-# Or specify the project directory explicitly:
-path/to/pr9k/bin/ralph-tui <iterations> -project-dir path/to/pr9k
+# Cap at N iterations:
+path/to/pr9k/bin/ralph-tui -n <iterations>
 
-# Or build and run directly (without make):
+# Specify the project directory explicitly:
+path/to/pr9k/bin/ralph-tui -p path/to/pr9k
+
+# Build and run directly (without make):
 cd path/to/pr9k/ralph-tui && go build -o ../ralph-tui ./cmd/ralph-tui
-path/to/pr9k/ralph-tui <iterations>
+path/to/pr9k/ralph-tui -n <iterations>
 ```
+
+Omitting `-n` (or passing `-n 0`) runs Ralph in until-done mode: it keeps picking up issues until `get_next_issue` finds none. Passing `-n N` caps the run at N iterations.
 
 Use `go build` — `go run` won't work because the project directory is resolved from the executable path.
 

--- a/docs/adr/20260409135303-cobra-cli-framework.md
+++ b/docs/adr/20260409135303-cobra-cli-framework.md
@@ -60,8 +60,8 @@ Migration effort from stdlib `flag` to the chosen framework was explicitly not a
 
 **Neutral:**
 
-- The existing `cli.Config` struct and `args_test.go` test suite will need to be rewritten to use cobra's patterns
-- The `reorderArgs()` function and its tests can be deleted entirely
+- The `cli.Config` struct was preserved; `args_test.go` was rewritten with 16 cobra-based test cases
+- The `reorderArgs()` function and its tests were deleted entirely
 
 ## Notes
 
@@ -69,9 +69,9 @@ Migration effort from stdlib `flag` to the chosen framework was explicitly not a
 
 | File | Purpose |
 |------|---------|
-| `ralph-tui/internal/cli/args.go` | Current CLI parsing logic to be replaced |
-| `ralph-tui/internal/cli/args_test.go` | Current test suite (11 cases) to be rewritten |
-| `ralph-tui/cmd/ralph-tui/main.go` | Entry point that calls `cli.ParseArgs()` and wires config into the app |
+| `ralph-tui/internal/cli/args.go` | CLI parsing via cobra: `Execute`, `NewCommand`, `Config`, `resolveProjectDir` |
+| `ralph-tui/internal/cli/args_test.go` | 16 test cases covering all cobra parsing branches |
+| `ralph-tui/cmd/ralph-tui/main.go` | Entry point that calls `cli.Execute()` and wires config into the app |
 | `ralph-tui/internal/workflow/run.go` | Downstream consumer of `cli.Config` via `workflow.RunConfig` |
 
 ### Related Docs

--- a/docs/adr/20260409135303-cobra-cli-framework.md
+++ b/docs/adr/20260409135303-cobra-cli-framework.md
@@ -54,7 +54,7 @@ Migration effort from stdlib `flag` to the chosen framework was explicitly not a
 
 **Negative:**
 
-- More boilerplate than kong or urfave/cli — requires `cmd/` package structure with `init()` functions per subcommand
+- More boilerplate than kong or urfave/cli — cobra's typical pattern uses a `cmd/` package with `init()` functions per subcommand, though this project used a single-file `internal/cli/args.go` approach instead
 - Positional arguments are received as `[]string` and require manual type conversion and validation
 - Adds 4 transitive dependencies (pflag, mousetrap, go-md2man, yaml.v3)
 

--- a/docs/adr/20260409135303-cobra-cli-framework.md
+++ b/docs/adr/20260409135303-cobra-cli-framework.md
@@ -1,0 +1,80 @@
+# Use Cobra for CLI Argument Parsing
+
+- **Status:** proposed
+- **Date Created:** 2026-04-09 13:53
+- **Last Updated:** 2026-04-09 13:53
+- **Authors:**
+  - River Bailey (mxriverlynn, river.bailey@testdouble.com)
+- **Reviewers:**
+
+## Context
+
+The ralph-tui Go application currently uses Go's stdlib `flag` package for CLI argument parsing (`ralph-tui/internal/cli/args.go`). This works for the current minimal interface (one positional `iterations` argument and an optional `-project-dir` flag), but requires a custom `reorderArgs()` function to work around `flag`'s limitation of stopping at the first non-flag argument.
+
+The project needs to add POSIX-style flags (`--long-flag`) and subcommand support, neither of which stdlib `flag` provides. A third-party CLI framework is needed.
+
+## Decision Drivers
+
+- **Long-term ecosystem support** — the chosen library must be actively maintained with a large community to avoid future migration headaches
+- **POSIX-style flags** — support for `--long-flag` and `-s` short flags
+- **Subcommand support** — ability to define subcommands (e.g., `ralph-tui run`, `ralph-tui config`)
+- **Help generation** — automatic, well-formatted help output
+
+## Considered Options
+
+1. **spf13/cobra** — Industry-standard Go CLI framework used by kubectl, Docker CLI, Hugo, and GitHub CLI. Provides subcommands, POSIX flags (via pflag), auto-generated help/man pages, and shell completions. Uses a multi-file `cmd/` package pattern with `init()` registration functions. 4 transitive dependencies (pflag, mousetrap, go-md2man, yaml.v3).
+
+   - Pros: Largest Go CLI ecosystem; battle-tested in major projects; extensive documentation; shell completion generation; active maintenance
+   - Cons: More boilerplate than alternatives (~100 lines across 3+ files for a basic subcommand); `init()` registration pattern adds ceremony; positional args require manual type conversion
+
+2. **alecthomas/kong** — Struct-tag-driven declarative CLI framework. Subcommands defined via embedded structs. Automatic type conversion from struct field types. ~30 lines for the same functionality as cobra's ~100.
+
+   - Pros: Minimal boilerplate; existing `Config` struct maps naturally to kong's model; automatic type parsing; near-zero dependencies
+   - Cons: Significantly smaller community; struct-tag errors are opaque to debug; less documentation; fewer projects using it in production
+
+3. **urfave/cli v3** — Procedural API with `Command` slices. ~60 lines for the same functionality. Zero external dependencies.
+
+   - Pros: Less boilerplate than cobra; no external dependencies; straightforward procedural API
+   - Cons: Smaller ecosystem than cobra; v2-to-v3 migration caused community disruption; less battle-tested at v3
+
+## Decision
+
+We will use **spf13/cobra** because long-term ecosystem stability and community support are the primary concerns. Cobra is the de facto standard for Go CLI applications, backed by the largest community, the most production usage, and the most active maintenance. The additional boilerplate compared to kong or urfave/cli is an acceptable tradeoff for the confidence that the framework will remain supported and well-documented for years to come.
+
+Migration effort from stdlib `flag` to the chosen framework was explicitly not a factor in this decision.
+
+## Consequences
+
+**Positive:**
+
+- POSIX-style flags and subcommands out of the box, eliminating the custom `reorderArgs()` workaround
+- Auto-generated help text, shell completions, and man pages
+- Extensive community resources, tutorials, and examples for onboarding contributors
+- Reduced risk of needing to migrate again due to an abandoned or poorly-supported library
+
+**Negative:**
+
+- More boilerplate than kong or urfave/cli — requires `cmd/` package structure with `init()` functions per subcommand
+- Positional arguments are received as `[]string` and require manual type conversion and validation
+- Adds 4 transitive dependencies (pflag, mousetrap, go-md2man, yaml.v3)
+
+**Neutral:**
+
+- The existing `cli.Config` struct and `args_test.go` test suite will need to be rewritten to use cobra's patterns
+- The `reorderArgs()` function and its tests can be deleted entirely
+
+## Notes
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `ralph-tui/internal/cli/args.go` | Current CLI parsing logic to be replaced |
+| `ralph-tui/internal/cli/args_test.go` | Current test suite (11 cases) to be rewritten |
+| `ralph-tui/cmd/ralph-tui/main.go` | Entry point that calls `cli.ParseArgs()` and wires config into the app |
+| `ralph-tui/internal/workflow/run.go` | Downstream consumer of `cli.Config` via `workflow.RunConfig` |
+
+### Related Docs
+
+- [CLI Configuration Feature Doc](../features/cli-configuration.md) — documents current flag parsing and project directory resolution
+- [Architecture Overview](../architecture.md) — system-level architecture including CLI entry point

--- a/docs/adr/20260409135303-cobra-cli-framework.md
+++ b/docs/adr/20260409135303-cobra-cli-framework.md
@@ -1,8 +1,8 @@
 # Use Cobra for CLI Argument Parsing
 
-- **Status:** proposed
+- **Status:** accepted
 - **Date Created:** 2026-04-09 13:53
-- **Last Updated:** 2026-04-09 13:53
+- **Last Updated:** 2026-04-09
 - **Authors:**
   - River Bailey (mxriverlynn, river.bailey@testdouble.com)
 - **Reviewers:**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ Built with [Glyph](https://useglyph.sh/) for TUI rendering, ralph-tui streams su
 │  │                    workflow.Run (goroutine)                     ││
 │  │                                                                 ││
 │  │  ┌─────────────────────────────────────────────────────────┐    ││
-│  │  │              Iteration Loop (1..N)                      │    ││
+│  │  │     Iteration Loop (1..N, or until no issue found)      │    ││
 │  │  │                                                         │    ││
 │  │  │  get_next_issue → git rev-parse HEAD → build steps      │    ││
 │  │  │       │                                                 │    ││
@@ -144,7 +144,7 @@ The `Runner` executes workflow steps as subprocesses, streaming stdout/stderr in
 
 ### [Workflow Orchestration](features/workflow-orchestration.md)
 
-The top-level `Run` function drives the entire workflow: displays a startup banner, fetches the GitHub username, loops over N iterations (each fetching an issue and running 8 steps through the step sequencer), then runs the finalization phase (deferred work, lessons learned, final push). The `Orchestrate` function sequences resolved steps, manages step state transitions, and handles error recovery by blocking on user input.
+The top-level `Run` function drives the entire workflow: displays a startup banner, fetches the GitHub username, loops over iterations (bounded to N when `--iterations N > 0`, or running until no issue is found when `--iterations 0`), then runs the finalization phase (deferred work, lessons learned, final push). The `Orchestrate` function sequences resolved steps, manages step state transitions, and handles error recovery by blocking on user input.
 
 **Packages:** `internal/workflow/` (`run.go`), `internal/ui/` (`orchestrate.go`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,8 +12,8 @@ Built with [Glyph](https://useglyph.sh/) for TUI rendering, ralph-tui streams su
 │                                                                     │
 │  ┌──────────────┐  ┌──────────────┐  ┌───────────────────────────┐  │
 │  │  CLI Parsing │  │ Step Loading │  │    OS Signal Handling     │  │
-│  │  (cli.Parse  │  │ (steps.Load  │  │  SIGINT/SIGTERM → chan    │  │
-│  │   Args)      │  │  Steps)      │  │  → KeyHandler.ForceQuit   │  │
+│  │  (cli.       │  │ (steps.Load  │  │  SIGINT/SIGTERM → chan    │  │
+│  │   Execute)   │  │  Steps)      │  │  → KeyHandler.ForceQuit   │  │
 │  └──────┬───────┘  └──────┬───────┘  └───────────┬───────────────┘  │
 │         │                 │                      │                  │
 │         ▼                 ▼                      ▼                  │
@@ -126,7 +126,7 @@ Each feature is documented in detail in its own file under [`docs/features/`](fe
 
 ### [CLI & Configuration](features/cli-configuration.md)
 
-Parses command-line arguments (`<iterations>` and optional `-project-dir` flag) and resolves the project directory. Uses a `reorderArgs` workaround to allow flags in any position despite Go's `flag` package stopping at the first positional argument. Resolves the project directory from the executable path via `os.Executable()` + `filepath.EvalSymlinks`.
+Parses command-line flags (`--iterations`/`-n` and `--project-dir`/`-p`) using [spf13/cobra](https://github.com/spf13/cobra) and resolves the project directory. Iterations defaults to 0 (run until done). Resolves the project directory from the executable path via `os.Executable()` + `filepath.EvalSymlinks` when `--project-dir` is not given.
 
 **Package:** `internal/cli/`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,5 +205,5 @@ cmd/ralph-tui/main.go
   - [Concurrency](coding-standards/concurrency.md) — Mutex patterns, WaitGroup drain, channel dispatch, non-blocking sends
   - [Error Handling](coding-standards/error-handling.md) — Package-prefixed errors, file paths in I/O errors, scanner error checking
   - [API Design](coding-standards/api-design.md) — Bounds guards, precondition validation, adapter types, platform assumptions
-  - [Go Patterns](coding-standards/go-patterns.md) — Flag reordering, symlink-safe paths, slice immutability, scanner buffers
+  - [Go Patterns](coding-standards/go-patterns.md) — Symlink-safe paths, slice immutability, scanner buffers
   - [Testing](coding-standards/testing.md) — Race detector, idempotent close, bounds testing, test doubles with mutexes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,7 +150,7 @@ The top-level `Run` function drives the entire workflow: displays a startup bann
 
 ### [TUI Status Header](features/tui-display.md)
 
-A pointer-mutable status display that Glyph reads on each render cycle. Shows the current iteration/issue on one line and step progress as two rows of 4 checkboxes each (8 steps total). Each step displays as `[ ]` (pending), `[▸]` (active), `[✓]` (done), or `[✗]` (failed). Switches to finalization mode with its own step names when the iteration loop completes.
+A pointer-mutable status display that Glyph reads on each render cycle. Shows the current iteration/issue on one line — `Iteration N/M` in bounded mode or `Iteration N` (no total) when running unbounded (`--iterations 0`). Step progress displays as two rows of 4 checkboxes each (8 steps total), where each step shows as `[ ]` (pending), `[▸]` (active), `[✓]` (done), or `[✗]` (failed). Switches to finalization mode with its own step names when the iteration loop completes.
 
 **Package:** `internal/ui/` (`header.go`, `log.go`)
 

--- a/docs/coding-standards/go-patterns.md
+++ b/docs/coding-standards/go-patterns.md
@@ -1,24 +1,5 @@
 # Go Patterns
 
-## Reorder args to work around Go flag package limitations
-
-Go's `flag` package stops parsing at the first non-flag argument. If flags can appear after positional arguments on the command line, use a `reorderArgs` helper to partition the args slice into flags-first, positionals-last before calling `fs.Parse`.
-
-```go
-// reorderArgs moves all -flag and --flag entries before positional args.
-func reorderArgs(args []string) []string {
-    var flags, positionals []string
-    for _, a := range args {
-        if strings.HasPrefix(a, "-") {
-            flags = append(flags, a)
-        } else {
-            positionals = append(positionals, a)
-        }
-    }
-    return append(flags, positionals...)
-}
-```
-
 ## Resolve binary path with os.Executable + filepath.EvalSymlinks
 
 When a binary needs to locate sibling files (e.g., configs, scripts) relative to itself, use `os.Executable()` followed by `filepath.EvalSymlinks` to get the real path. Skipping `EvalSymlinks` breaks when the binary is installed as a symlink.
@@ -68,7 +49,7 @@ scanner.Buffer(make([]byte, scanBufSize), scanBufSize)
 ## Additional Information
 
 - [Architecture Overview](../architecture.md) — System-level architecture and design principles
-- [CLI & Configuration](../features/cli-configuration.md) — Flag reordering in ParseArgs and symlink-safe project directory resolution
+- [CLI & Configuration](../features/cli-configuration.md) — Symlink-safe project directory resolution in `resolveProjectDir`
 - [Subprocess Execution & Streaming](../features/subprocess-execution.md) — 256KB scanner buffer and ResolveCommand slice immutability
 - [Step Definitions & Prompt Building](../features/step-definitions.md) — Slice allocation in buildIterationSteps/buildFinalizeSteps
 - [Testing](testing.md) — Standards for runtime.Caller(0) in test helpers and input slice immutability tests

--- a/docs/coding-standards/go-patterns.md
+++ b/docs/coding-standards/go-patterns.md
@@ -46,10 +46,82 @@ scanner := bufio.NewScanner(pipe)
 scanner.Buffer(make([]byte, scanBufSize), scanBufSize)
 ```
 
+## Extract conditional format strings to a named pure helper
+
+When the same conditional formatting decision (e.g., bounded vs. unbounded, singular vs. plural) appears in multiple log or UI call sites, extract it as a named unexported function rather than repeating the condition inline. This makes the formatting logic independently testable and keeps the condition in one place.
+
+```go
+// iterationLabel returns "Iteration N/M" for bounded mode or "Iteration N" for unbounded (total == 0).
+func iterationLabel(i, total int) string {
+    if total > 0 {
+        return fmt.Sprintf("Iteration %d/%d", i, total)
+    }
+    return fmt.Sprintf("Iteration %d", i)
+}
+
+// Call sites stay readable and stay in sync automatically:
+executor.WriteToLog(fmt.Sprintf("%s — No issue found.", iterationLabel(i, cfg.Iterations)))
+executor.WriteToLog(ui.StepSeparator(fmt.Sprintf("%s — Issue #%s", iterationLabel(i, cfg.Iterations), issueID)))
+```
+
+## Cobra: share command definition with an unexported impl helper
+
+When you need both a `NewCommand()` (for tests or embedding) and an `Execute()` (for `main`), extract an unexported `newCommandImpl(cfg *T, ranE *bool)` that builds the `cobra.Command`. Set `*ranE = true` at the top of `RunE`. `Execute()` uses this flag to distinguish a clean `--help` exit (RunE was never invoked) from a normal successful parse.
+
+```go
+func newCommandImpl(cfg *Config, ranE *bool) *cobra.Command {
+    cmd := &cobra.Command{
+        RunE: func(cmd *cobra.Command, args []string) error {
+            *ranE = true
+            // validation ...
+            return nil
+        },
+    }
+    // flag definitions ...
+    return cmd
+}
+
+func NewCommand(cfg *Config) *cobra.Command {
+    return newCommandImpl(cfg, new(bool))
+}
+
+func Execute() (*Config, error) {
+    cfg := &Config{}
+    var ranE bool
+    cmd := newCommandImpl(cfg, &ranE)
+    if err := cmd.Execute(); err != nil {
+        return nil, err
+    }
+    if !ranE {
+        return nil, nil // --help was invoked; RunE was skipped
+    }
+    return cfg, nil
+}
+```
+
+## Cobra: guard against nil config returned by Execute()
+
+`cobra.Command.Execute()` short-circuits when `--help` is requested — it prints usage and returns nil without running `RunE`. Any wrapper that returns a config struct must signal this to its caller. The caller must guard before dereferencing.
+
+```go
+// In main:
+cfg, err := cli.Execute()
+if err != nil {
+    fmt.Fprintf(os.Stderr, "Error: %v\nRun 'ralph-tui --help' for usage.\n", err)
+    os.Exit(1)
+}
+if cfg == nil {
+    os.Exit(0) // --help was shown; nothing to do
+}
+```
+
+Do not treat `(nil, nil)` as an error — it is the documented --help path.
+
 ## Additional Information
 
 - [Architecture Overview](../architecture.md) — System-level architecture and design principles
-- [CLI & Configuration](../features/cli-configuration.md) — Symlink-safe project directory resolution in `resolveProjectDir`
+- [CLI & Configuration](../features/cli-configuration.md) — Symlink-safe project directory resolution in `resolveProjectDir`; cobra Execute nil guard in `main.go`
+- [Workflow Orchestration](../features/workflow-orchestration.md) — `iterationLabel` conditional format helper applied across log call sites
 - [Subprocess Execution & Streaming](../features/subprocess-execution.md) — 256KB scanner buffer and ResolveCommand slice immutability
 - [Step Definitions & Prompt Building](../features/step-definitions.md) — Slice allocation in buildIterationSteps/buildFinalizeSteps
 - [Testing](testing.md) — Standards for runtime.Caller(0) in test helpers and input slice immutability tests

--- a/docs/coding-standards/testing.md
+++ b/docs/coding-standards/testing.md
@@ -96,6 +96,22 @@ func (s *spyHeader) getCalls() []string {
 }
 ```
 
+## Test names must match actual test scope
+
+Name tests by what they actually exercise. A test named `TestFoo_BoundedMode` that also covers the unbounded path misleads reviewers and future maintainers about what is and isn't tested.
+
+- If a test covers a single path, name it for that path: `TestIterationLabel_Bounded`, `TestIterationLabel_Unbounded`.
+- If a test covers multiple paths in one table, name it for the function: `TestIterationLabel` or `TestIterationLabel_Modes`.
+- Never let the name claim narrower coverage than the test body provides — that gap is how blind spots form.
+
+```go
+// Bad: name implies bounded-only, but the table includes unbounded rows
+func TestIterationLabel_BoundedMode(t *testing.T) { ... }
+
+// Good: name matches actual scope
+func TestIterationLabel(t *testing.T) { ... }
+```
+
 ## Verify go vet before committing
 
 Run `go vet ./...` before every commit. Vet catches correctness issues that the compiler does not (e.g., misuse of `sync` types, incorrect format strings).
@@ -103,6 +119,7 @@ Run `go vet ./...` before every commit. Vet catches correctness issues that the 
 ## Additional Information
 
 - [Architecture Overview](../architecture.md) — System-level architecture and interface-driven testability design principle
+- [Workflow Orchestration](../features/workflow-orchestration.md) — `TestIterationLabel` as an example of a test name matching full scope (bounded + unbounded)
 - [File Logging](../features/file-logging.md) — Close idempotency testing applied to Logger
 - [TUI Status Header](../features/tui-display.md) — Bounds guard testing on SetStepState and SetFinalizeStepState
 - [Subprocess Execution & Streaming](../features/subprocess-execution.md) — WasTerminated flag reset testing, input slice immutability in ResolveCommand

--- a/docs/features/cli-configuration.md
+++ b/docs/features/cli-configuration.md
@@ -169,7 +169,7 @@ Within `workflow.Run`, `ProjectDir` resolves additional paths:
 | Positional argument given | cobra error (`"unknown command"` / `"accepts 0 arg(s)"`) | Exit 1 |
 | Cannot resolve executable | `"cli: could not resolve project dir: ..."` | Exit 1 |
 
-All errors are written to stderr and cause `os.Exit(1)`.
+All errors are written to stderr followed by a `Run 'ralph-tui --help' for usage.` hint, and cause `os.Exit(1)`.
 
 ## Configuration
 

--- a/docs/features/cli-configuration.md
+++ b/docs/features/cli-configuration.md
@@ -1,22 +1,22 @@
 # CLI & Configuration
 
-Parses command-line arguments and resolves the project directory that anchors all relative path resolution throughout ralph-tui.
+Parses command-line flags and resolves the project directory that anchors all relative path resolution throughout ralph-tui.
 
-- **Last Updated:** 2026-04-08 12:00
+- **Last Updated:** 2026-04-09
 - **Authors:**
   - River Bailey
 
 ## Overview
 
-- ralph-tui accepts a required `<iterations>` positional argument and an optional `-project-dir` flag
-- The `reorderArgs` function works around Go's `flag` package limitation of stopping at the first positional argument, allowing flags in any position
-- When `-project-dir` is not provided, the project directory is resolved from the executable's real path via `os.Executable()` + `filepath.EvalSymlinks` (symlink-safe)
+- ralph-tui accepts an optional `--iterations` / `-n` flag (default 0 = run until done) and an optional `--project-dir` / `-p` flag
+- Built on [spf13/cobra](https://github.com/spf13/cobra), which handles POSIX-style flags in any position — no custom reordering needed
+- When `--project-dir` is not provided, the project directory is resolved from the executable's real path via `os.Executable()` + `filepath.EvalSymlinks` (symlink-safe)
 - `ProjectDir` fans out to every subsystem: logger, step loader, prompt builder, command resolver, and the workflow runner
 
 Key files:
-- `ralph-tui/internal/cli/args.go` — ParseArgs, Config, reorderArgs, resolveProjectDir
-- `ralph-tui/internal/cli/args_test.go` — 10 test cases covering all argument parsing branches
-- `ralph-tui/cmd/ralph-tui/main.go` — Entry point that calls ParseArgs and distributes Config
+- `ralph-tui/internal/cli/args.go` — `Execute`, `NewCommand`, `Config`, `resolveProjectDir`
+- `ralph-tui/internal/cli/args_test.go` — 16 test cases covering all argument parsing branches
+- `ralph-tui/cmd/ralph-tui/main.go` — Entry point that calls `Execute` and distributes `Config`
 
 ## Architecture
 
@@ -25,17 +25,13 @@ Key files:
                              │
                              ▼
                       ┌─────────────┐
-                      │ reorderArgs │  move flags before positionals
-                      └──────┬──────┘
-                             │
-                             ▼
-                      ┌─────────────┐
-                      │  flag.Parse  │  extract -project-dir
+                      │    cobra    │  parse --iterations, --project-dir
+                      │  (pflag)    │
                       └──────┬──────┘
                              │
                   ┌──────────┴──────────┐
                   │                     │
-           -project-dir given     not given
+           --project-dir given     not given
                   │                     │
                   │              ┌──────▼──────────┐
                   │              │resolveProjectDir │
@@ -63,68 +59,77 @@ Key files:
 
 | File | Purpose |
 |------|---------|
-| `ralph-tui/internal/cli/args.go` | ParseArgs, Config struct, reorderArgs, resolveProjectDir |
+| `ralph-tui/internal/cli/args.go` | `Execute`, `NewCommand`, `Config` struct, `resolveProjectDir` |
 | `ralph-tui/internal/cli/args_test.go` | Unit tests for all argument parsing branches |
-| `ralph-tui/cmd/ralph-tui/main.go` | Entry point — calls ParseArgs, distributes Config to subsystems |
+| `ralph-tui/cmd/ralph-tui/main.go` | Entry point — calls `Execute`, distributes `Config` to subsystems |
 
 ## Core Types
 
 ```go
 // Config holds parsed CLI arguments.
 type Config struct {
-    Iterations int    // number of workflow iterations to run (must be > 0)
+    Iterations int    // number of workflow iterations to run (0 = run until done)
     ProjectDir string // root directory for all relative path resolution
 }
 ```
 
 ## Implementation Details
 
-### Argument Parsing
+### Entry Point
 
-`ParseArgs` creates an isolated `flag.FlagSet` with `flag.ContinueOnError` (returns errors instead of calling `os.Exit`). It defines one flag (`-project-dir`) and validates the positional `iterations` argument:
+`Execute` creates a `Config`, builds a cobra command via `newCommandImpl`, and runs it against `os.Args`. It uses a `ranE` sentinel to distinguish `--help` (RunE not invoked) from a successful parse:
 
 ```go
-func ParseArgs(args []string) (*Config, error) {
-    fs := flag.NewFlagSet("ralph-tui", flag.ContinueOnError)
-    projectDir := fs.String("project-dir", "", "path to the project directory")
-
-    // Reorder so flags work in any position
-    if err := fs.Parse(reorderArgs(args)); err != nil {
+func Execute() (*Config, error) {
+    cfg := &Config{}
+    var ranE bool
+    cmd := newCommandImpl(cfg, &ranE)
+    if err := cmd.Execute(); err != nil {
         return nil, err
     }
-
-    positional := fs.Args()
-    if len(positional) == 0 {
-        return nil, errors.New("missing required argument: iterations")
+    if !ranE {
+        return nil, nil // --help was requested
     }
-
-    iterations, err := strconv.Atoi(positional[0])
-    // ... validates iterations > 0, resolves projectDir if empty
+    return cfg, nil
 }
 ```
 
-### Flag Reordering
+Return values:
+- `(cfg, nil)` — successful parse, workflow should start
+- `(nil, nil)` — `--help` requested, exit cleanly
+- `(nil, err)` — flag parsing or validation failed, exit 1
 
-Go's `flag` package stops parsing at the first non-flag token. Without `reorderArgs`, `ralph-tui 3 -project-dir /tmp` would leave `-project-dir` unprocessed. The function splits args into flag and positional slices, then returns flags first:
+### Argument Parsing
+
+`newCommandImpl` builds the cobra command with `cobra.NoArgs` (positional arguments are rejected) and defines two flags:
 
 ```go
-func reorderArgs(args []string) []string {
-    var flagArgs, positionalArgs []string
-    // Walk args: tokens starting with "-" are flags (with their values),
-    // "--" terminates flag scanning, everything else is positional.
-    return append(flagArgs, positionalArgs...)
-}
+cmd.Flags().IntVarP(&cfg.Iterations, "iterations", "n", 0, "number of iterations to run (0 = run until done)")
+cmd.Flags().StringVarP(&cfg.ProjectDir, "project-dir", "p", "", "path to the project directory (default: resolved from executable)")
 ```
 
-This enables both argument orders:
-- `ralph-tui -project-dir /tmp 3`
-- `ralph-tui 3 -project-dir /tmp`
+RunE validates and resolves:
 
-Edge case: a negative number like `-1` is treated as a flag by `reorderArgs`. Use `--` to force it as positional: `ralph-tui -- -1` (which then fails validation since iterations must be > 0).
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    *ranE = true
+    if cfg.Iterations < 0 {
+        return errors.New("cli: --iterations must be a non-negative integer")
+    }
+    if cfg.ProjectDir == "" {
+        dir, err := resolveProjectDir()
+        if err != nil {
+            return fmt.Errorf("cli: could not resolve project dir: %w", err)
+        }
+        cfg.ProjectDir = dir
+    }
+    return nil
+},
+```
 
 ### Project Directory Resolution
 
-When `-project-dir` is not provided, the project directory is inferred from the compiled binary's location:
+When `--project-dir` is not provided, the project directory is inferred from the compiled binary's location:
 
 ```go
 func resolveProjectDir() (string, error) {
@@ -136,7 +141,7 @@ func resolveProjectDir() (string, error) {
 
 `filepath.EvalSymlinks` is critical: without it, a symlinked binary (e.g., installed in `~/bin/`) would resolve to the symlink's directory rather than where `configs/`, `prompts/`, and `scripts/` actually live.
 
-This is why `go run` does not work — it places the binary in a temporary directory. Use `go build` and run the compiled binary, or pass `-project-dir` explicitly.
+This is why `go run` does not work — it places the binary in a temporary directory. Use `go build` and run the compiled binary, or pass `--project-dir` explicitly.
 
 ### ProjectDir Fan-Out
 
@@ -159,53 +164,59 @@ Within `workflow.Run`, `ProjectDir` resolves additional paths:
 
 | Scenario | Error Message | Behavior |
 |----------|---------------|----------|
-| No arguments | `"missing required argument: iterations"` | Exit 1 |
-| Non-integer iterations | `"iterations must be an integer, got %q"` | Exit 1 |
-| Zero or negative iterations | `"iterations must be > 0"` | Exit 1 |
-| Unknown flag | flag package error (e.g., `"flag provided but not defined: -foo"`) | Exit 1 |
-| Cannot resolve executable | `"could not resolve project dir: ..."` | Exit 1 |
+| Negative iterations | `"cli: --iterations must be a non-negative integer"` | Exit 1 |
+| Unknown flag | pflag error (e.g., `"unknown flag: --foo"`) | Exit 1 |
+| Positional argument given | cobra error (`"unknown command"` / `"accepts 0 arg(s)"`) | Exit 1 |
+| Cannot resolve executable | `"cli: could not resolve project dir: ..."` | Exit 1 |
 
 All errors are written to stderr and cause `os.Exit(1)`.
 
 ## Configuration
 
-| Flag | Description | Default |
-|------|-------------|---------|
-| `-project-dir` | Path to the project root directory | Resolved from executable location |
+| Flag | Short | Description | Default |
+|------|-------|-------------|---------|
+| `--iterations` | `-n` | Number of iterations to run (0 = run until done) | `0` |
+| `--project-dir` | `-p` | Path to the project root directory | Resolved from executable location |
 
 **Usage:**
 
 ```
-ralph-tui <iterations> [-project-dir <path>]
+ralph-tui [--iterations <n>] [--project-dir <path>]
 ```
 
 ## Testing
 
-- `ralph-tui/internal/cli/args_test.go` — 10 test cases covering all ParseArgs branches
+- `ralph-tui/internal/cli/args_test.go` — 16 test cases covering all `NewCommand` and `Execute` branches
 
 ### Test Cases
 
 | Test | What It Validates |
 |------|-------------------|
-| `TestParseArgs_ValidIterations` | Happy path with `-project-dir` flag |
-| `TestParseArgs_MissingIterations` | Empty args returns error |
-| `TestParseArgs_ZeroIterations` | `"0"` is rejected |
-| `TestParseArgs_ProjectDirOverride` | `-project-dir` value is used directly |
-| `TestParseArgs_DefaultProjectDir` | Without flag, `ProjectDir` is non-empty (from executable) |
-| `TestParseArgs_NonIntegerIterations` | `"abc"` returns error |
-| `TestParseArgs_NegativeIterationsViaFlag` | `-1` treated as unknown flag |
-| `TestParseArgs_NegativeIterationsViaSeparator` | `-- -1` reaches integer validator |
-| `TestParseArgs_FlagBeforePositional` | Confirms `reorderArgs` works |
-| `TestParseArgs_UnknownFlag` | Unknown flag returns error |
-| `TestParseArgs_LargeIterations` | `"1000"` is accepted |
+| `TestNewCommand_NoFlags` | No flags → iterations=0, project-dir resolved from executable (non-empty) |
+| `TestNewCommand_LongIterationsFlag` | `--iterations 3` → iterations=3 |
+| `TestNewCommand_ShortIterationsFlag` | `-n 3` → iterations=3 |
+| `TestNewCommand_NegativeIterations` | `--iterations -1` → error containing expected message |
+| `TestNewCommand_LongProjectDirFlag` | `--project-dir /tmp/foo` → project-dir=/tmp/foo |
+| `TestNewCommand_ShortProjectDirFlag` | `-p /tmp/foo` → project-dir=/tmp/foo |
+| `TestNewCommand_BothFlags` | `-n 3 -p /tmp/foo` → both fields set |
+| `TestNewCommand_PositionalArgRejected` | `["somearg"]` → error from cobra.NoArgs |
+| `TestNewCommand_UnknownFlag` | `["--unknown"]` → error |
+| `TestExecute_HelpReturnsNilNil` | `--help` → RunE not invoked (ranE=false) |
+| `TestNewCommand_EqualsSyntax` | `--iterations=3` → iterations=3 |
+| `TestNewCommand_IterationsNoValue` | `--iterations` with no value → error |
+| `TestNewCommand_ShortIterationsNoValue` | `-n` with no value → error |
+| `TestNewCommand_ArgsAfterSeparatorRejected` | `-- extraarg` → error from cobra.NoArgs |
+| `TestNewCommand_ExplicitZeroIterations` | `-n 0` → iterations=0 (until-done mode) |
+| `TestNewCommand_LargeIterations` | `-n 1000` → accepted |
 
 ## Additional Information
 
 - [Architecture Overview](../architecture.md) — System-level view of ralph-tui with block diagrams and data flow
+- [ADR: Use Cobra for CLI Argument Parsing](../adr/20260409135303-cobra-cli-framework.md) — Decision rationale for replacing stdlib `flag` with cobra
 - [Building Custom Workflows](../how-to/building-custom-workflows.md) — How ProjectDir affects config and prompt file resolution
 - [Step Definitions & Prompt Building](step-definitions.md) — How ProjectDir resolves config and prompt files
 - [Subprocess Execution & Streaming](subprocess-execution.md) — How ProjectDir sets the working directory for subprocesses
 - [Workflow Orchestration](workflow-orchestration.md) — How RunConfig carries ProjectDir and Iterations into the Run loop
 - [File Logging](file-logging.md) — How ProjectDir determines the log file location
 - [ralph-tui Plan](../plans/ralph-tui.md) — Original specification including CLI design decisions
-- [Go Patterns](../coding-standards/go-patterns.md) — Coding standards for flag reordering and symlink-safe path resolution
+- [Go Patterns](../coding-standards/go-patterns.md) — Coding standards for symlink-safe path resolution

--- a/docs/features/tui-display.md
+++ b/docs/features/tui-display.md
@@ -2,14 +2,15 @@
 
 Manages the visual status display for the ralph-tui terminal interface, showing iteration progress, step checkboxes, and step separator formatting.
 
-- **Last Updated:** 2026-04-08 12:00
+- **Last Updated:** 2026-04-09
 - **Authors:**
   - River Bailey
 
 ## Overview
 
 - `StatusHeader` is a pointer-mutable struct that Glyph reads on each render cycle — callers update state by mutating fields directly
-- Displays the current iteration/issue on one line and step progress as two rows of 4 checkboxes (8 steps total)
+- Displays the current iteration/issue on one line; shows `Iteration N/M` in bounded mode and `Iteration N` (no total) when total is 0 (unbounded mode)
+- Displays step progress as two rows of 4 checkboxes (8 steps total)
 - Each step shows one of four states: `[ ]` pending, `[▸]` active, `[✓]` done, `[✗]` failed
 - Switches between iteration mode and finalization mode with different step names
 - `StepSeparator` and `RetryStepSeparator` produce formatted separator lines written to the log pipe between steps
@@ -29,7 +30,8 @@ Key files:
   ┌─────────────────────────────────────────────┐
   │              StatusHeader                    │
   │                                              │
-  │  IterationLine: "Iteration 1/3 — Issue #42" │
+  │  IterationLine: "Iteration 1/3 — Issue #42" │  ← bounded (total > 0)
+  │  IterationLine: "Iteration 1 — Issue #42"   │  ← unbounded (total == 0)
   │                                              │
   │  Row1: [▸] Feature work  [✓] Test planning   │
   │        [ ] Test writing   [ ] Code review     │
@@ -75,7 +77,8 @@ const (
 // StatusHeader manages pointer-mutable string state for the TUI.
 // Glyph reads exported fields via pointer on each render cycle.
 type StatusHeader struct {
-    IterationLine string    // e.g., "Iteration 1/3 — Issue #42: Add widget support"
+    IterationLine string    // e.g., "Iteration 1/3 — Issue #42: Add widget support" (bounded)
+                            //    or "Iteration 1 — Issue #42: Add widget support" (unbounded, total==0)
     Row1          [4]string // checkbox labels for steps 0-3
     Row2          [4]string // checkbox labels for steps 4-7
     stepNames     [8]string
@@ -99,11 +102,15 @@ func NewStatusHeader(stepNames [8]string) *StatusHeader {
 }
 ```
 
-`SetIteration` updates the iteration line. `SetStepState` updates individual step checkboxes (0-indexed, mapped to Row1[0-3] and Row2[0-3]):
+`SetIteration` updates the iteration line. When `total > 0` the line shows `N/M`; when `total == 0` (unbounded mode, run until done) the total is omitted. `SetStepState` updates individual step checkboxes (0-indexed, mapped to Row1[0-3] and Row2[0-3]):
 
 ```go
 func (h *StatusHeader) SetIteration(current, total int, issueID, issueTitle string) {
-    h.IterationLine = fmt.Sprintf("Iteration %d/%d — Issue #%s: %s", current, total, issueID, issueTitle)
+    if total > 0 {
+        h.IterationLine = fmt.Sprintf("Iteration %d/%d — Issue #%s: %s", current, total, issueID, issueTitle)
+    } else {
+        h.IterationLine = fmt.Sprintf("Iteration %d — Issue #%s: %s", current, issueID, issueTitle)
+    }
 }
 
 func (h *StatusHeader) SetStepState(idx int, state StepState) {
@@ -155,7 +162,7 @@ These are passed to `Runner.WriteToLog()` by the orchestration loop.
 
 ## Testing
 
-- `ralph-tui/internal/ui/header_test.go` — Tests for NewStatusHeader, SetIteration, SetStepState, SetFinalization, SetFinalizeStepState, bounds guards
+- `ralph-tui/internal/ui/header_test.go` — Tests for NewStatusHeader, SetIteration (bounded and unbounded), SetStepState, SetFinalization, SetFinalizeStepState, bounds guards
 - `ralph-tui/internal/ui/log_test.go` — Tests for StepSeparator and RetryStepSeparator output
 
 ## Additional Information

--- a/docs/features/workflow-orchestration.md
+++ b/docs/features/workflow-orchestration.md
@@ -2,13 +2,14 @@
 
 Drives the entire ralph-tui workflow: iterating over GitHub issues, sequencing steps with error recovery, and running finalization tasks.
 
-- **Last Updated:** 2026-04-08 12:00
+- **Last Updated:** 2026-04-09
 - **Authors:**
   - River Bailey
 
 ## Overview
 
-- `Run()` is the top-level orchestration goroutine that manages the full lifecycle: banner display, GitHub user lookup, N iteration loops, finalization phase, and completion summary
+- `Run()` is the top-level orchestration goroutine that manages the full lifecycle: banner display, GitHub user lookup, iteration loop, finalization phase, and completion summary
+- The iteration loop runs for exactly N iterations when `Iterations > 0`, or until no issue is found when `Iterations == 0` (unbounded / run-until-done mode)
 - `Orchestrate()` sequences resolved steps, manages step state transitions (pending → active → done/failed), and handles interactive error recovery
 - Iteration steps are resolved per-iteration with the current issue ID and commit SHA; finalization steps are resolved once
 - The orchestration communicates with the keyboard handler via a `StepAction` channel for quit, continue, and retry decisions
@@ -118,9 +119,9 @@ type ResolvedStep struct {
 
 1. **Banner** — displays the embedded `ralph-art.txt` banner (compiled into the binary via `//go:embed`)
 2. **GitHub username** — calls `scripts/get_gh_user` via `CaptureOutput`
-3. **Iteration loop** — for each iteration (1..N):
+3. **Iteration loop** — runs from i=1 upward, stopping when `i > Iterations` (bounded) or when no issue is found (unbounded, `Iterations == 0`):
    - Fetches the next issue via `scripts/get_next_issue`
-   - If no issue found, exits the loop early
+   - If no issue found, exits the loop early (the only exit condition in unbounded mode)
    - Captures the current HEAD SHA
    - Updates the status header
    - Builds resolved steps via `buildIterationSteps`
@@ -199,6 +200,21 @@ func runStepWithErrorHandling(...) StepAction {
     }
 }
 ```
+
+### Iteration Label Formatting
+
+`iterationLabel` centralizes the progress display for both bounded and unbounded modes so the format is consistent across log messages and step separators:
+
+```go
+func iterationLabel(i, total int) string {
+    if total > 0 {
+        return fmt.Sprintf("Iteration %d/%d", i, total)
+    }
+    return fmt.Sprintf("Iteration %d", i)
+}
+```
+
+It is called wherever an iteration identifier appears in log output: the "no issue found" early-exit message and the `StepSeparator` line written before each iteration's steps.
 
 ### Header Adapters
 

--- a/docs/plans/cobra-cli-option-parsing.md
+++ b/docs/plans/cobra-cli-option-parsing.md
@@ -75,6 +75,8 @@ None — all design decisions resolved.
   - `SilenceErrors: true`, `SilenceUsage: true` — prevents cobra from printing its own error/usage output, since `main.go` already handles error formatting
   - Flags: `--iterations` / `-n` (int, default 0), `--project-dir` / `-p` (string, default "")
   - `RunE`: validate `--iterations >= 0`, resolve project-dir if empty, populate `Config`
+  - Error messages from `RunE` must use `cli:` package prefix per coding standard (e.g., `"cli: --iterations must be a non-negative integer"`, `"cli: could not resolve project dir: %w"`)
+  - Note: pflag-generated errors (e.g., `--iterations abc` failing int parse, or unknown flags) bypass `RunE` entirely and will not carry the `cli:` prefix. This is acceptable — pflag errors are self-describing and include the flag name. Wrapping them would require a custom `FlagErrorFunc` for marginal benefit.
 - Add `Execute() (*Config, error)`:
   - Creates `&Config{}`, calls `NewCommand(cfg)`, runs `cmd.Execute()`, returns the config
   - **Guard against `--help`/no-`RunE` path:** Track whether `RunE` actually executed (e.g., a `bool` set inside `RunE`). If `cmd.Execute()` returns nil but `RunE` never ran (help was printed), return `nil, nil` — `main.go` checks for `cfg == nil` and exits cleanly without starting the workflow
@@ -92,11 +94,17 @@ None — all design decisions resolved.
   - Positional args rejected (cobra.NoArgs)
   - Unknown flags rejected
   - `--help` → Execute() returns nil config, nil error (no workflow started)
+  - `--iterations=3` (equals syntax) → iterations=3 (pflag handles natively)
+  - `--iterations` with no value → error from pflag
+  - `-n` with no value → error from pflag
+  - `-- extraarg` → error from cobra.NoArgs (args after `--` are still positional)
+  - `-n 0` (explicit zero) → iterations=0, equivalent to omitting (until-done mode)
   - Large iteration counts accepted
 
 ### Step 4: Update `cmd/ralph-tui/main.go`
 - Replace `cfg, err := cli.ParseArgs(os.Args[1:])` with `cfg, err := cli.Execute()`
 - Add nil check: if `cfg == nil && err == nil`, exit 0 (help was printed, no work to do)
+- Update error output to include a help hint: `fmt.Fprintf(os.Stderr, "error: %v\nRun 'ralph-tui --help' for usage.\n", err)` — compensates for `SilenceUsage: true` which prevents cobra from printing usage on flag errors
 - Rest of main.go unchanged — it already consumes `cfg.Iterations` and `cfg.ProjectDir`
 
 ### Step 5: Update loop in `workflow/run.go`
@@ -109,23 +117,34 @@ None — all design decisions resolved.
   - "No issue found" log (line 76): bounded → `"Iteration 3/5 — No issue found."`, unbounded → `"Iteration 3 — No issue found."`
   - Use a helper or inline conditional to format `iterationLabel(i, total)` for both messages
 - Pass `cfg.Iterations` (which is 0 for unbounded) to `header.SetIteration(i, cfg.Iterations, ...)`
+- Completion summary (line 124) is intentionally unchanged — it uses `iterationsRun` (actual count), not `cfg.Iterations`, so it works correctly for both bounded and unbounded modes
 
 ### Step 6: Update header formatting in UI
 - In `SetIteration` implementation, use conditional formatting:
   - `total > 0`: `fmt.Sprintf("Iteration %d/%d — Issue #%s: %s", current, total, issueID, issueTitle)`
   - `total == 0`: `fmt.Sprintf("Iteration %d — Issue #%s: %s", current, issueID, issueTitle)`
+- Add test in `header_test.go` for the `total == 0` (unbounded) path:
+  - `h.SetIteration(3, 0, "42", "Add widget support")` → `"Iteration 3 — Issue #42: Add widget support"` (no total shown)
 
 ### Step 7: Update workflow tests
-- Add/update tests in `workflow/run_test.go` (if exists) to cover unbounded loop behavior
-- Verify bounded loop still works as before
+- `workflow/run_test.go` exists and has test infrastructure (fakeExecutor, fakeRunHeader, helper functions)
+- Add tests for unbounded loop (`Iterations: 0`):
+  - Unbounded loop runs until `get_next_issue` returns empty — set up captureResults with 2 issues then empty, assert 2 iteration steps ran
+  - Unbounded loop still runs finalization after exhausting issues
+  - Unbounded loop's `SetIteration` calls pass `total=0`
+  - Format strings in log lines use `"Iteration N"` (no total) for unbounded, `"Iteration N/M"` for bounded
+- Add bounded-mode regression test: 3 issues available but `Iterations: 2`, verify only 2 iterations run and the third issue is not fetched — guards against regression in the new conditional loop construct
+- Verify existing bounded loop tests still pass as before (existing tests use `Iterations: 1`, `Iterations: 2`, `Iterations: 3` — all remain valid)
 
 ### Step 8: Update documentation
 - Update all files that reference the old `ralph-tui <iterations>` positional syntax:
-  - `CLAUDE.md` (lines 48, 52) — change to `ralph-tui [-n <iterations>] [-p <project-dir>]`
+  - `README.md` (lines 34, 45, 48, 52) — change to `ralph-tui [-n <iterations>] [-p <project-dir>]`
+  - `CLAUDE.md` (lines 48, 52) — same
   - `docs/project-discovery.md` (line 41) — same
   - `docs/features/cli-configuration.md` — rewrite to reflect cobra flags, remove `reorderArgs` documentation
   - `docs/plans/ralph-tui.md` (lines 432, 438, 648) — update examples
-  - `docs/architecture.md` — update if it references CLI syntax
+  - `docs/architecture.md` (line 129) — update CLI description to reflect cobra flags; remove `reorderArgs` reference
+  - `docs/coding-standards/go-patterns.md` — remove or replace the "Reorder args to work around Go flag package limitations" section; cobra/pflag eliminates this pattern entirely
 - Document the new "until done" mode (omitting `--iterations` runs until no issues remain)
 
 ### Step 9: Verify and clean up
@@ -137,20 +156,23 @@ None — all design decisions resolved.
 
 ## Review Summary
 
-**Iterations completed:** 3 (stopped at iteration 3 — below 80% chance of structural improvement)
+**Iterations completed:** 3 (stopped at iteration 3 — below 80% chance of structural improvement), plus full agent validation
 
-**Assumptions challenged:** 13 primary and secondary assumptions evaluated across iterations:
-- 10 verified against codebase evidence
-- 2 revealed gaps that required plan changes (A9: SilenceErrors, A12: NewCommand signature)
-- 1 uncertain, clarified (A11: loop construct)
+**Assumptions challenged:** 18 primary and secondary assumptions evaluated across 3 iterations:
+- 15 verified against codebase evidence
+- 3 revealed gaps that required plan changes:
+  - A12: Step 8 missing documentation files (architecture.md, go-patterns.md) — added
+  - A11: header_test.go missing test for `total == 0` — added to Step 6
+  - A13: Error messages should use package prefix per coding standard — added to Step 2
 
-**Agent validation findings incorporated:**
-- Evidence-based investigator: confirmed 5/6 assumptions, found 1 missing loop exit path (`buildIterationSteps` error break) — added to Step 5
-- Adversarial validator: found 3 actionable gaps:
-  - V1: `--help` returns unpopulated config — added `RunE`-executed guard to `Execute()` and nil-config check to `main.go`
-  - V3: 5+ documentation files reference old CLI syntax — added Step 8 (documentation update)
-  - V4: `SetIteration` format variants not explicit — specified both in Step 6
-  - V2: unbounded loop infinite-loop risk — documented as accepted risk with rationale
+**Agent validation findings incorporated (round 2):**
+- Evidence-based investigator: confirmed 8/9 assumptions. Finding on `SetFinalization` format string was evaluated as false positive — finalization always has a known step count, unaffected by iteration mode.
+- Adversarial validator: found 4 actionable gaps:
+  - V3: `README.md` (4 lines) missing from Step 8 documentation update list — added
+  - V5: pflag-generated errors bypass `RunE` and lack `cli:` prefix — documented as acceptable exception in Step 2
+  - V6: `SilenceUsage: true` removes help guidance on flag errors — added help hint to Step 4 error output
+  - V7: Missing bounded-mode regression test (more issues available than iterations cap) — added to Step 7
+- Confirmed safe: `--help` guard pattern (V1), `cobra.NoArgs` with `--` separator (V2), integer overflow in unbounded loop (V4)
 
 **Consolidations:** None needed (no internal or external overlap detected)
 

--- a/docs/plans/cobra-cli-option-parsing.md
+++ b/docs/plans/cobra-cli-option-parsing.md
@@ -19,6 +19,10 @@ Replace the stdlib `flag`-based CLI parsing in `ralph-tui/internal/cli/args.go` 
 
 None — all design decisions resolved.
 
+## Accepted Risks
+
+1. **Unbounded loop with no safety cap.** When `--iterations` is omitted (until-done mode), the loop relies entirely on `get_next_issue` returning empty to terminate. If issue processing fails to make progress (e.g., same issue returned repeatedly due to a close-issue failure), the loop runs indefinitely. This is accepted because: (a) the user can always Ctrl-C to exit, (b) adding an arbitrary cap would undermine the "run until done" intent, and (c) duplicate-issue detection adds complexity disproportionate to the risk. Can be revisited if real-world usage reveals a problem.
+
 ## Decisions
 
 1. **`iterations` becomes a flag, not a positional argument.** Use `--iterations` / `-n` with automatic int parsing via cobra/pflag. Eliminates manual `strconv.Atoi` and makes help output self-documenting. Command becomes `ralph-tui -n 3` or `ralph-tui --iterations 3`.
@@ -39,7 +43,7 @@ None — all design decisions resolved.
 
 9. **Defer `--project-dir` resolution to `RunE`.** Default is `""`. In `RunE`, if the flag wasn't provided, call `resolveProjectDir()` and return any error through cobra's error path. Keeps command construction infallible.
 
-10. **Export `NewCommand() *cobra.Command` and test against it.** `Execute()` calls `NewCommand()` internally. Tests create the command via `NewCommand()`, use `cmd.SetArgs()`, and execute. Tests the real cobra wiring including flag parsing, defaults, and validation.
+10. **Export `NewCommand(cfg *Config) *cobra.Command` and test against it.** `Execute()` creates a `&Config{}` and passes it to `NewCommand()`. `RunE` populates the config through the pointer. Tests create their own `&Config{}`, call `NewCommand(cfg)`, use `cmd.SetArgs()`, execute, and inspect `cfg`. Tests the real cobra wiring including flag parsing, defaults, and validation.
 
 11. **Reject negative `--iterations` values.** `RunE` returns an error for `--iterations < 0`. Error message: `"--iterations must be a non-negative integer"`. Valid range: `0` (until done) or any positive integer.
 
@@ -65,16 +69,18 @@ None — all design decisions resolved.
 ### Step 2: Rewrite `internal/cli/args.go` with cobra
 - Delete `ParseArgs()` and `reorderArgs()`
 - Keep `resolveProjectDir()` and `Config` struct
-- Add `NewCommand() *cobra.Command`:
+- Add `NewCommand(cfg *Config) *cobra.Command` (accepts a pointer that `RunE` populates — allows `Execute()` to return the config and tests to inspect it):
   - `Use: "ralph-tui [flags]"`, `Short`, `Long` per decision #15
   - `Args: cobra.NoArgs`
+  - `SilenceErrors: true`, `SilenceUsage: true` — prevents cobra from printing its own error/usage output, since `main.go` already handles error formatting
   - Flags: `--iterations` / `-n` (int, default 0), `--project-dir` / `-p` (string, default "")
   - `RunE`: validate `--iterations >= 0`, resolve project-dir if empty, populate `Config`
 - Add `Execute() (*Config, error)`:
-  - Calls `NewCommand()`, runs `cmd.Execute()`, returns the config
+  - Creates `&Config{}`, calls `NewCommand(cfg)`, runs `cmd.Execute()`, returns the config
+  - **Guard against `--help`/no-`RunE` path:** Track whether `RunE` actually executed (e.g., a `bool` set inside `RunE`). If `cmd.Execute()` returns nil but `RunE` never ran (help was printed), return `nil, nil` — `main.go` checks for `cfg == nil` and exits cleanly without starting the workflow
 
 ### Step 3: Rewrite `internal/cli/args_test.go`
-- Test via `NewCommand()` + `cmd.SetArgs()` + `cmd.Execute()`
+- Test via `cfg := &Config{}` + `NewCommand(cfg)` + `cmd.SetArgs()` + `cmd.Execute()` + assert on `cfg`
 - Cover:
   - No flags → iterations=0, project-dir resolved from executable
   - `--iterations 3` → iterations=3
@@ -85,31 +91,67 @@ None — all design decisions resolved.
   - Both flags together
   - Positional args rejected (cobra.NoArgs)
   - Unknown flags rejected
+  - `--help` → Execute() returns nil config, nil error (no workflow started)
   - Large iteration counts accepted
 
 ### Step 4: Update `cmd/ralph-tui/main.go`
 - Replace `cfg, err := cli.ParseArgs(os.Args[1:])` with `cfg, err := cli.Execute()`
+- Add nil check: if `cfg == nil && err == nil`, exit 0 (help was printed, no work to do)
 - Rest of main.go unchanged — it already consumes `cfg.Iterations` and `cfg.ProjectDir`
 
 ### Step 5: Update loop in `workflow/run.go`
-- Change `for i := 1; i <= cfg.Iterations; i++` to support both modes:
-  - When `cfg.Iterations > 0`: bounded loop (same as today but using the flag value)
-  - When `cfg.Iterations == 0`: unbounded loop, exits only when `get_next_issue` returns empty
-- Adjust format strings:
-  - Bounded: `"Iteration 3/5 — Issue #42"` (same as today)
-  - Unbounded: `"Iteration 3 — Issue #42"` (no total)
+- Replace `for i := 1; i <= cfg.Iterations; i++` with `for i := 1; cfg.Iterations == 0 || i <= cfg.Iterations; i++` — runs unbounded when 0, bounded otherwise. Preserve all existing early-exit paths:
+  - `break` when `get_next_issue` returns empty (line 75-78)
+  - `break` when `buildIterationSteps` returns an error (line 94-96)
+  - `return` when `Orchestrate` returns `ActionQuit` (line 99-101)
+- Adjust all format strings that use `%d/%d` iteration formatting:
+  - Separator log: bounded → `"Iteration 3/5 — Issue #42"`, unbounded → `"Iteration 3 — Issue #42"`
+  - "No issue found" log (line 76): bounded → `"Iteration 3/5 — No issue found."`, unbounded → `"Iteration 3 — No issue found."`
+  - Use a helper or inline conditional to format `iterationLabel(i, total)` for both messages
 - Pass `cfg.Iterations` (which is 0 for unbounded) to `header.SetIteration(i, cfg.Iterations, ...)`
 
 ### Step 6: Update header formatting in UI
-- In `SetIteration` implementation: if `total == 0`, format as `"Iteration %d"` without total
+- In `SetIteration` implementation, use conditional formatting:
+  - `total > 0`: `fmt.Sprintf("Iteration %d/%d — Issue #%s: %s", current, total, issueID, issueTitle)`
+  - `total == 0`: `fmt.Sprintf("Iteration %d — Issue #%s: %s", current, issueID, issueTitle)`
 
 ### Step 7: Update workflow tests
 - Add/update tests in `workflow/run_test.go` (if exists) to cover unbounded loop behavior
 - Verify bounded loop still works as before
 
-### Step 8: Verify and clean up
+### Step 8: Update documentation
+- Update all files that reference the old `ralph-tui <iterations>` positional syntax:
+  - `CLAUDE.md` (lines 48, 52) — change to `ralph-tui [-n <iterations>] [-p <project-dir>]`
+  - `docs/project-discovery.md` (line 41) — same
+  - `docs/features/cli-configuration.md` — rewrite to reflect cobra flags, remove `reorderArgs` documentation
+  - `docs/plans/ralph-tui.md` (lines 432, 438, 648) — update examples
+  - `docs/architecture.md` — update if it references CLI syntax
+- Document the new "until done" mode (omitting `--iterations` runs until no issues remain)
+
+### Step 9: Verify and clean up
 - `make test` — all tests pass with `-race`
 - `make lint` — no lint issues
 - `make vet` — no vet issues
 - `make build` — binary builds and runs
 - Delete any remaining dead code (confirm `reorderArgs` is gone, no orphan imports)
+
+## Review Summary
+
+**Iterations completed:** 3 (stopped at iteration 3 — below 80% chance of structural improvement)
+
+**Assumptions challenged:** 13 primary and secondary assumptions evaluated across iterations:
+- 10 verified against codebase evidence
+- 2 revealed gaps that required plan changes (A9: SilenceErrors, A12: NewCommand signature)
+- 1 uncertain, clarified (A11: loop construct)
+
+**Agent validation findings incorporated:**
+- Evidence-based investigator: confirmed 5/6 assumptions, found 1 missing loop exit path (`buildIterationSteps` error break) — added to Step 5
+- Adversarial validator: found 3 actionable gaps:
+  - V1: `--help` returns unpopulated config — added `RunE`-executed guard to `Execute()` and nil-config check to `main.go`
+  - V3: 5+ documentation files reference old CLI syntax — added Step 8 (documentation update)
+  - V4: `SetIteration` format variants not explicit — specified both in Step 6
+  - V2: unbounded loop infinite-loop risk — documented as accepted risk with rationale
+
+**Consolidations:** None needed (no internal or external overlap detected)
+
+**Ambiguities resolved:** 0 surfaced (all design questions were pre-resolved in the decisions section)

--- a/docs/plans/cobra-cli-option-parsing.md
+++ b/docs/plans/cobra-cli-option-parsing.md
@@ -1,0 +1,115 @@
+# Plan: Integrate Cobra for CLI Option Parsing
+
+**Status:** ready
+**ADR:** [20260409135303-cobra-cli-framework.md](../adr/20260409135303-cobra-cli-framework.md)
+
+## Goal
+
+Replace the stdlib `flag`-based CLI parsing in `ralph-tui/internal/cli/args.go` with spf13/cobra, gaining POSIX-style flags, subcommands, and auto-generated help.
+
+## Current State
+
+- Entry point: `ralph-tui/cmd/ralph-tui/main.go` calls `cli.ParseArgs(os.Args[1:])`
+- Parsing: `ralph-tui/internal/cli/args.go` uses `flag.FlagSet` + custom `reorderArgs()`
+- Config struct: `cli.Config{Iterations int, ProjectDir string}`
+- Tests: `ralph-tui/internal/cli/args_test.go` (11 test cases)
+- Downstream consumer: `workflow.RunConfig` receives `Config.ProjectDir` and `Config.Iterations`
+
+## Open Questions
+
+None — all design decisions resolved.
+
+## Decisions
+
+1. **`iterations` becomes a flag, not a positional argument.** Use `--iterations` / `-n` with automatic int parsing via cobra/pflag. Eliminates manual `strconv.Atoi` and makes help output self-documenting. Command becomes `ralph-tui -n 3` or `ralph-tui --iterations 3`.
+
+2. **`iterations` is optional; omitting it means "run until no work remains."** When `--iterations` is not provided, the loop runs continuously until `get_next_issue` finds no more issues. When provided, it caps at that count. This changes loop semantics from "always fixed count" to "fixed count OR until-done."
+
+3. **Represent "until done" as `Iterations == 0` in `cli.Config`.** Keep `Iterations int` (no pointer, no extra bool). Zero is a safe sentinel since zero iterations is never a valid user request. Cobra's default int value is `0`, so the zero-value semantics align naturally.
+
+4. **Root command only, no subcommands.** There's only one action today (run the loop). Subcommands can be added later trivially. No need to introduce a `run` subcommand with nothing to distinguish it from.
+
+5. **Cobra command definition stays in `internal/cli/`.** No `cmd/` package pattern -- we don't have subcommands to organize. Keeps the diff small, preserves existing package structure, and `internal/` correctly signals this is not a public API. Can move to `cmd/` pattern later if subcommands warrant it.
+
+6. **`cli.Execute() (*Config, error)` returns the parsed config.** The cobra `RunE` validates and stores config in a local variable; `Execute` returns it. Most similar to today's `cli.ParseArgs()` call site, no package-level state, no callback ceremony. `main.go` changes from `cli.ParseArgs(os.Args[1:])` to `cli.Execute()`.
+
+7. **`--project-dir` defaults to executable-relative resolution.** Keep the existing `resolveProjectDir()` logic (os.Executable + EvalSymlinks). This is load-bearing: ralph-steps.json, prompts, and scripts all resolve relative to projectDir.
+
+8. **`--project-dir` / `-p` short flag.** Both long and short forms available.
+
+9. **Defer `--project-dir` resolution to `RunE`.** Default is `""`. In `RunE`, if the flag wasn't provided, call `resolveProjectDir()` and return any error through cobra's error path. Keeps command construction infallible.
+
+10. **Export `NewCommand() *cobra.Command` and test against it.** `Execute()` calls `NewCommand()` internally. Tests create the command via `NewCommand()`, use `cmd.SetArgs()`, and execute. Tests the real cobra wiring including flag parsing, defaults, and validation.
+
+11. **Reject negative `--iterations` values.** `RunE` returns an error for `--iterations < 0`. Error message: `"--iterations must be a non-negative integer"`. Valid range: `0` (until done) or any positive integer.
+
+12. **Use `cobra.NoArgs` to reject unexpected positional arguments.** Both args are flags now, so any positional arg is a user mistake. Fails fast with a clear error.
+
+13. **Loop changes in `workflow/run.go` are included in this plan.** The "run until done" semantics are coupled to the flag change -- shipping `--iterations 0` without loop support would be broken. Changes: replace bounded `for i := 1; i <= N; i++` with conditional loop, and adjust display formatting to omit total when running in until-done mode (e.g., `"Iteration 3"` instead of `"Iteration 3/5"`).
+
+14. **Pass `total=0` to `SetIteration` to mean "unknown total."** No interface signature change. The header implementation checks `if total == 0` to format as `"Iteration 3"` vs `"Iteration 3/5"`. Same sentinel logic as `Config.Iterations`.
+
+15. **Cobra command descriptions:**
+    - `Use`: `"ralph-tui [flags]"`
+    - `Short`: `"Automated development workflow orchestrator"`
+    - `Long`: `"ralph-tui drives the claude CLI through multi-step coding loops. By default, it picks up GitHub issues labeled \"ralph\", implements features, writes tests, runs code reviews, and pushes — all unattended. Custom workflow definitions can be provided to tailor the steps to your needs."`
+
+16. **Replace `args.go` entirely.** Delete `reorderArgs()` and `ParseArgs()` -- both are replaced by the cobra implementation. Keep `resolveProjectDir()` (still needed). Rewrite `args_test.go` to test against `NewCommand()`. Clean break, no dead code.
+
+## Implementation Steps
+
+### Step 1: Add cobra dependency
+- `cd ralph-tui && go get github.com/spf13/cobra`
+- Verify `go.mod` includes cobra and its transitive deps (pflag, mousetrap, go-md2man, yaml.v3)
+
+### Step 2: Rewrite `internal/cli/args.go` with cobra
+- Delete `ParseArgs()` and `reorderArgs()`
+- Keep `resolveProjectDir()` and `Config` struct
+- Add `NewCommand() *cobra.Command`:
+  - `Use: "ralph-tui [flags]"`, `Short`, `Long` per decision #15
+  - `Args: cobra.NoArgs`
+  - Flags: `--iterations` / `-n` (int, default 0), `--project-dir` / `-p` (string, default "")
+  - `RunE`: validate `--iterations >= 0`, resolve project-dir if empty, populate `Config`
+- Add `Execute() (*Config, error)`:
+  - Calls `NewCommand()`, runs `cmd.Execute()`, returns the config
+
+### Step 3: Rewrite `internal/cli/args_test.go`
+- Test via `NewCommand()` + `cmd.SetArgs()` + `cmd.Execute()`
+- Cover:
+  - No flags → iterations=0, project-dir resolved from executable
+  - `--iterations 3` → iterations=3
+  - `-n 3` → iterations=3
+  - `--iterations -1` → error
+  - `--project-dir /tmp/foo` → project-dir=/tmp/foo
+  - `-p /tmp/foo` → project-dir=/tmp/foo
+  - Both flags together
+  - Positional args rejected (cobra.NoArgs)
+  - Unknown flags rejected
+  - Large iteration counts accepted
+
+### Step 4: Update `cmd/ralph-tui/main.go`
+- Replace `cfg, err := cli.ParseArgs(os.Args[1:])` with `cfg, err := cli.Execute()`
+- Rest of main.go unchanged — it already consumes `cfg.Iterations` and `cfg.ProjectDir`
+
+### Step 5: Update loop in `workflow/run.go`
+- Change `for i := 1; i <= cfg.Iterations; i++` to support both modes:
+  - When `cfg.Iterations > 0`: bounded loop (same as today but using the flag value)
+  - When `cfg.Iterations == 0`: unbounded loop, exits only when `get_next_issue` returns empty
+- Adjust format strings:
+  - Bounded: `"Iteration 3/5 — Issue #42"` (same as today)
+  - Unbounded: `"Iteration 3 — Issue #42"` (no total)
+- Pass `cfg.Iterations` (which is 0 for unbounded) to `header.SetIteration(i, cfg.Iterations, ...)`
+
+### Step 6: Update header formatting in UI
+- In `SetIteration` implementation: if `total == 0`, format as `"Iteration %d"` without total
+
+### Step 7: Update workflow tests
+- Add/update tests in `workflow/run_test.go` (if exists) to cover unbounded loop behavior
+- Verify bounded loop still works as before
+
+### Step 8: Verify and clean up
+- `make test` — all tests pass with `-race`
+- `make lint` — no lint issues
+- `make vet` — no vet issues
+- `make build` — binary builds and runs
+- Delete any remaining dead code (confirm `reorderArgs` is gone, no orphan imports)

--- a/docs/plans/cobra-cli-option-parsing.md
+++ b/docs/plans/cobra-cli-option-parsing.md
@@ -1,6 +1,6 @@
 # Plan: Integrate Cobra for CLI Option Parsing
 
-**Status:** ready
+**Status:** done
 **ADR:** [20260409135303-cobra-cli-framework.md](../adr/20260409135303-cobra-cli-framework.md)
 
 ## Goal

--- a/docs/plans/ralph-tui.md
+++ b/docs/plans/ralph-tui.md
@@ -299,7 +299,7 @@ type StepFile struct {
 func loadSteps(projectDir string) (StepFile, error) {
     // projectDir is the repo root, resolved at startup via os.Executable().
     // Note: os.Executable() returns a temp path when using `go run`.
-    // During development, use `go build` or pass the -project-dir flag (see CLI args below).
+    // During development, use `go build` or pass the --project-dir flag (see CLI args below).
     data, err := os.ReadFile(filepath.Join(projectDir, "ralph-steps.json"))
     if err != nil {
         return StepFile{}, fmt.Errorf("could not read ralph-steps.json: %w", err)

--- a/docs/plans/ralph-tui.md
+++ b/docs/plans/ralph-tui.md
@@ -37,7 +37,7 @@ The `ralph-bash/ralph-loop` bash script runs multiple sequential `claude` CLI ca
 ### Three sections, top to bottom:
 
 **1. Status header (fixed height)**
-- Current iteration and total: `Iteration 1/3`
+- Current iteration and total: `Iteration 1/3` (bounded mode); `Iteration 1` (unbounded mode — when `--iterations` is omitted or `0`)
 - Issue being worked: `Issue #42: Add widget support`
 - Step tracker with checkboxes across two rows showing all 8 steps per iteration
 - Status indicators: `[✓]` done, `[▸ ...]` active (with spinner), `[ ]` pending
@@ -562,7 +562,7 @@ Both flags use POSIX-style parsing via [spf13/cobra](https://github.com/spf13/co
 ### UI: Status header (`internal/ui/ui.go`)
 
 **Acceptance criteria:**
-- Displays current iteration number and total (e.g., `Iteration 1/3`)
+- Displays current iteration number and total (e.g., `Iteration 1/3`); omits the total in unbounded mode when `SetIteration` is called with `total == 0` (e.g., `Iteration 1`)
 - Displays the issue being worked (e.g., `Issue #42: Add widget support`)
 - Shows 8 step checkboxes across two rows
 - Step indicators: `[✓]` done, `[▸ ...]` active with spinner, `[ ]` pending
@@ -570,6 +570,7 @@ Both flags use POSIX-style parsing via [spf13/cobra](https://github.com/spf13/co
 
 **Unit tests:**
 - Set iteration to 2/5 — verify the iteration line string is formatted correctly
+- Set iteration with `total == 0` — verify the line omits the total (`Iteration N` instead of `Iteration N/M`)
 - Mark steps 1-3 as done, step 4 as active, rest pending — verify checkbox states
 - Switch to finalization mode — verify header shows `Finalizing` and finalization step names
 - All 8 steps fit across two rows of 4

--- a/docs/plans/ralph-tui.md
+++ b/docs/plans/ralph-tui.md
@@ -429,13 +429,13 @@ pr9k/                               # repo root (projectDir)
 ## CLI Arguments
 
 ```
-ralph-tui <iterations> [-project-dir <path>]
+ralph-tui [-n <iterations>] [-p <project-dir>]
 ```
 
-- **`<iterations>`** (required) — Number of iterations to run. Must be > 0.
-- **`-project-dir <path>`** (optional) — Override the auto-detected project directory (repo root). Useful during development with `go run`, where `os.Executable()` returns a temp path. When omitted, `projectDir` is resolved via `os.Executable()` with `filepath.EvalSymlinks`.
+- **`--iterations` / `-n`** (optional) — Number of iterations to run. Defaults to `0`, which means run until `get_next_issue` finds no more issues (until-done mode). Pass a positive integer to cap the run.
+- **`--project-dir` / `-p`** (optional) — Override the auto-detected project directory (repo root). Useful during development with `go run`, where `os.Executable()` returns a temp path. When omitted, `projectDir` is resolved via `os.Executable()` with `filepath.EvalSymlinks`.
 
-Flags may appear before or after positional arguments (e.g., both `ralph-tui 3 -project-dir /tmp` and `ralph-tui -project-dir /tmp 3` are valid). This is handled by `reorderArgs` in `internal/cli/args.go`, which moves flag args before positionals prior to parsing, working around Go's `flag` package stopping at the first non-flag argument.
+Both flags use POSIX-style parsing via [spf13/cobra](https://github.com/spf13/cobra). Positional arguments are rejected (`cobra.NoArgs`). No custom reordering is needed.
 
 ---
 
@@ -645,7 +645,7 @@ Flags may appear before or after positional arguments (e.g., both `ralph-tui 3 -
 ## Verification
 
 1. `cd ralph-tui && go build -o ../ralph-tui ./cmd/ralph-tui` — compiles and places binary at repo root (required for `os.Executable()` directory resolution)
-2. From the target repo, run with `path/to/pr9k/ralph-tui 1`
+2. From the target repo, run with `path/to/pr9k/ralph-tui -n 1`
 3. Verify: output streams line-by-line in the log panel as claude runs
 4. Verify: step checkboxes update as steps complete
 5. Verify: `j`/`k`/arrows scroll the log, auto-scroll resumes at bottom

--- a/docs/project-discovery.md
+++ b/docs/project-discovery.md
@@ -39,7 +39,7 @@
 ### Commands and Tests
 
 - Build: `make build` or `cd ralph-tui && go build -o ../ralph-tui ./cmd/ralph-tui`
-- Run: `./bin/ralph-tui <iterations>` or `./ralph-tui <iterations> [-project-dir <path>]`
+- Run: `./bin/ralph-tui [-n <iterations>] [-p <project-dir>]` (omit `-n` for until-done mode)
 - Test: `make test` or `cd ralph-tui && go test -race ./...`
 - Lint: `make lint` (requires golangci-lint)
 - Format check: `make format`

--- a/docs/project-discovery.md
+++ b/docs/project-discovery.md
@@ -1,6 +1,6 @@
 # Project Discovery
 
-- **Last Updated:** 2026-04-08
+- **Last Updated:** 2026-04-09
 
 ## Repository
 
@@ -28,10 +28,11 @@
 - Package manager: Go modules
 - Dependency manifest: `ralph-tui/go.mod`
 - Module: `github.com/mxriverlynn/pr9k/ralph-tui`
-- No external dependencies (Glyph TUI framework planned but not yet in go.mod)
+- External dependencies: `github.com/spf13/cobra` v1.10.2 (and transitive deps: pflag v1.0.9, mousetrap v1.1.0)
 
 ### Frameworks and Tooling
 
+- CLI: spf13/cobra v1.10.2 (ADR: [20260409135303-cobra-cli-framework](adr/20260409135303-cobra-cli-framework.md))
 - TUI: Glyph (planned, not yet in go.mod)
 - Task runner: Make (`Makefile` at repo root)
 

--- a/ralph-tui/cmd/ralph-tui/main.go
+++ b/ralph-tui/cmd/ralph-tui/main.go
@@ -16,10 +16,13 @@ import (
 )
 
 func main() {
-	cfg, err := cli.ParseArgs(os.Args[1:])
+	cfg, err := cli.Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
+	}
+	if cfg == nil {
+		os.Exit(0)
 	}
 
 	log, err := logger.NewLogger(cfg.ProjectDir)

--- a/ralph-tui/cmd/ralph-tui/main.go
+++ b/ralph-tui/cmd/ralph-tui/main.go
@@ -18,7 +18,7 @@ import (
 func main() {
 	cfg, err := cli.Execute()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error: %v\nRun 'ralph-tui --help' for usage.\n", err)
 		os.Exit(1)
 	}
 	if cfg == nil {

--- a/ralph-tui/go.mod
+++ b/ralph-tui/go.mod
@@ -1,3 +1,9 @@
 module github.com/mxriverlynn/pr9k/ralph-tui
 
 go 1.23
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/ralph-tui/go.mod
+++ b/ralph-tui/go.mod
@@ -2,8 +2,9 @@ module github.com/mxriverlynn/pr9k/ralph-tui
 
 go 1.23
 
+require github.com/spf13/cobra v1.10.2
+
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 )

--- a/ralph-tui/go.sum
+++ b/ralph-tui/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/ralph-tui/internal/cli/args.go
+++ b/ralph-tui/internal/cli/args.go
@@ -2,12 +2,9 @@ package cli
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -16,72 +13,6 @@ import (
 type Config struct {
 	Iterations int
 	ProjectDir string
-}
-
-// ParseArgs parses the command-line arguments (os.Args[1:]).
-// Returns an error for missing/invalid iterations or invalid flags.
-func ParseArgs(args []string) (*Config, error) {
-	fs := flag.NewFlagSet("ralph-tui", flag.ContinueOnError)
-	projectDir := fs.String("project-dir", "", "path to the project directory (default: resolved from executable)")
-
-	// Reorder args so flags appear before positionals; Go's flag package stops
-	// parsing at the first non-flag argument, so "3 -project-dir /tmp" would
-	// leave -project-dir unprocessed without this reordering.
-	if err := fs.Parse(reorderArgs(args)); err != nil {
-		return nil, err
-	}
-
-	positional := fs.Args()
-	if len(positional) == 0 {
-		return nil, errors.New("missing required argument: iterations")
-	}
-
-	iterations, err := strconv.Atoi(positional[0])
-	if err != nil {
-		return nil, fmt.Errorf("iterations must be an integer, got %q", positional[0])
-	}
-	if iterations <= 0 {
-		return nil, errors.New("iterations must be > 0")
-	}
-
-	dir := *projectDir
-	if dir == "" {
-		dir, err = resolveProjectDir()
-		if err != nil {
-			return nil, fmt.Errorf("could not resolve project dir: %w", err)
-		}
-	}
-
-	return &Config{
-		Iterations: iterations,
-		ProjectDir: dir,
-	}, nil
-}
-
-// reorderArgs moves flag args before positional args so Go's flag package
-// can parse them regardless of their original position in args.
-func reorderArgs(args []string) []string {
-	var flagArgs, positionalArgs []string
-	i := 0
-	for i < len(args) {
-		arg := args[i]
-		if arg == "--" {
-			positionalArgs = append(positionalArgs, args[i+1:]...)
-			break
-		}
-		if strings.HasPrefix(arg, "-") {
-			flagArgs = append(flagArgs, arg)
-			// If next arg looks like a flag value (doesn't start with -), include it
-			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") && args[i+1] != "--" {
-				i++
-				flagArgs = append(flagArgs, args[i])
-			}
-		} else {
-			positionalArgs = append(positionalArgs, arg)
-		}
-		i++
-	}
-	return append(flagArgs, positionalArgs...)
 }
 
 // resolveProjectDir returns the directory containing the executable,

--- a/ralph-tui/internal/cli/args.go
+++ b/ralph-tui/internal/cli/args.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 // Config holds parsed CLI arguments.
@@ -94,4 +96,56 @@ func resolveProjectDir() (string, error) {
 		return "", err
 	}
 	return filepath.Dir(resolved), nil
+}
+
+// newCommandImpl builds the cobra command, using ranE to track whether RunE executed.
+func newCommandImpl(cfg *Config, ranE *bool) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "ralph-tui [flags]",
+		Short:         "Automated development workflow orchestrator",
+		Long:          `ralph-tui drives the claude CLI through multi-step coding loops. By default, it picks up GitHub issues labeled "ralph", implements features, writes tests, runs code reviews, and pushes — all unattended. Custom workflow definitions can be provided to tailor the steps to your needs.`,
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			*ranE = true
+			if cfg.Iterations < 0 {
+				return errors.New("cli: --iterations must be a non-negative integer")
+			}
+			if cfg.ProjectDir == "" {
+				dir, err := resolveProjectDir()
+				if err != nil {
+					return fmt.Errorf("cli: could not resolve project dir: %w", err)
+				}
+				cfg.ProjectDir = dir
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntVarP(&cfg.Iterations, "iterations", "n", 0, "number of iterations to run (0 = run until done)")
+	cmd.Flags().StringVarP(&cfg.ProjectDir, "project-dir", "p", "", "path to the project directory (default: resolved from executable)")
+	return cmd
+}
+
+// NewCommand returns a configured cobra.Command that parses CLI flags into cfg.
+// RunE populates cfg when the command executes successfully.
+func NewCommand(cfg *Config) *cobra.Command {
+	return newCommandImpl(cfg, new(bool))
+}
+
+// Execute creates a Config, runs the cobra command, and returns the parsed config.
+// Returns (nil, nil) if --help was requested (RunE was not invoked).
+// Returns (nil, err) if parsing or validation failed.
+// Returns (cfg, nil) on success.
+func Execute() (*Config, error) {
+	cfg := &Config{}
+	var ranE bool
+	cmd := newCommandImpl(cfg, &ranE)
+	if err := cmd.Execute(); err != nil {
+		return nil, err
+	}
+	if !ranE {
+		return nil, nil
+	}
+	return cfg, nil
 }

--- a/ralph-tui/internal/cli/args_test.go
+++ b/ralph-tui/internal/cli/args_test.go
@@ -5,8 +5,36 @@ import (
 	"testing"
 )
 
-func TestParseArgs_ValidIterations(t *testing.T) {
-	cfg, err := ParseArgs([]string{"3", "-project-dir", "/tmp/foo"})
+// helper: build a NewCommand with a fresh Config and set args on it.
+func runNewCommand(t *testing.T, args []string) (*Config, error) {
+	t.Helper()
+	cfg := &Config{}
+	cmd := NewCommand(cfg)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// 1. No flags → iterations=0 (until-done), project-dir resolved from executable (non-empty).
+func TestNewCommand_NoFlags(t *testing.T) {
+	cfg, err := runNewCommand(t, []string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Iterations != 0 {
+		t.Errorf("expected iterations=0, got %d", cfg.Iterations)
+	}
+	if cfg.ProjectDir == "" {
+		t.Error("expected non-empty project-dir resolved from executable")
+	}
+}
+
+// 2. --iterations 3 → iterations=3.
+func TestNewCommand_LongIterationsFlag(t *testing.T) {
+	cfg, err := runNewCommand(t, []string{"--iterations", "3"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -15,22 +43,34 @@ func TestParseArgs_ValidIterations(t *testing.T) {
 	}
 }
 
-func TestParseArgs_MissingIterations(t *testing.T) {
-	_, err := ParseArgs([]string{})
-	if err == nil {
-		t.Fatal("expected error for missing iterations, got nil")
+// 3. -n 3 → iterations=3 (short flag).
+func TestNewCommand_ShortIterationsFlag(t *testing.T) {
+	cfg, err := runNewCommand(t, []string{"-n", "3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Iterations != 3 {
+		t.Errorf("expected iterations=3, got %d", cfg.Iterations)
 	}
 }
 
-func TestParseArgs_ZeroIterations(t *testing.T) {
-	_, err := ParseArgs([]string{"0"})
+// 4. --iterations -1 → error containing "--iterations must be a non-negative integer".
+func TestNewCommand_NegativeIterations(t *testing.T) {
+	cfg := &Config{}
+	cmd := NewCommand(cfg)
+	cmd.SetArgs([]string{"--iterations", "-1"})
+	err := cmd.Execute()
 	if err == nil {
-		t.Fatal("expected error for iterations=0, got nil")
+		t.Fatal("expected error for --iterations -1, got nil")
+	}
+	if !strings.Contains(err.Error(), "--iterations must be a non-negative integer") {
+		t.Errorf("expected error to contain %q, got %q", "--iterations must be a non-negative integer", err.Error())
 	}
 }
 
-func TestParseArgs_ProjectDirOverride(t *testing.T) {
-	cfg, err := ParseArgs([]string{"3", "-project-dir", "/tmp/foo"})
+// 5. --project-dir /tmp/foo → project-dir=/tmp/foo.
+func TestNewCommand_LongProjectDirFlag(t *testing.T) {
+	cfg, err := runNewCommand(t, []string{"--project-dir", "/tmp/foo"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -39,68 +79,128 @@ func TestParseArgs_ProjectDirOverride(t *testing.T) {
 	}
 }
 
-func TestParseArgs_DefaultProjectDir(t *testing.T) {
-	cfg, err := ParseArgs([]string{"1"})
+// 6. -p /tmp/foo → project-dir=/tmp/foo (short flag).
+func TestNewCommand_ShortProjectDirFlag(t *testing.T) {
+	cfg, err := runNewCommand(t, []string{"-p", "/tmp/foo"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	// The default is resolved from os.Executable(); just verify it's non-empty.
-	if cfg.ProjectDir == "" {
-		t.Error("expected non-empty default project dir")
-	}
-}
-
-// T1: non-integer iterations string
-func TestParseArgs_NonIntegerIterations(t *testing.T) {
-	_, err := ParseArgs([]string{"abc"})
-	if err == nil {
-		t.Fatal("expected error for non-integer iterations, got nil")
-	}
-	if !strings.Contains(err.Error(), "iterations must be an integer") {
-		t.Errorf("expected error to contain %q, got %q", "iterations must be an integer", err.Error())
-	}
-}
-
-// T2: negative iterations (via "--" separator to bypass flag parsing of "-1")
-func TestParseArgs_NegativeIterationsViaFlag(t *testing.T) {
-	_, err := ParseArgs([]string{"-1"})
-	if err == nil {
-		t.Fatal("expected error for -1 (interpreted as unknown flag), got nil")
-	}
-}
-
-func TestParseArgs_NegativeIterationsViaSeparator(t *testing.T) {
-	_, err := ParseArgs([]string{"--", "-1"})
-	if err == nil {
-		t.Fatal("expected error for iterations=-1, got nil")
-	}
-}
-
-// T4: flag before positional argument
-func TestParseArgs_FlagBeforePositional(t *testing.T) {
-	cfg, err := ParseArgs([]string{"-project-dir", "/tmp/foo", "5"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.Iterations != 5 {
-		t.Errorf("expected iterations=5, got %d", cfg.Iterations)
 	}
 	if cfg.ProjectDir != "/tmp/foo" {
 		t.Errorf("expected project-dir=/tmp/foo, got %q", cfg.ProjectDir)
 	}
 }
 
-// T5: unknown flags return an error
-func TestParseArgs_UnknownFlag(t *testing.T) {
-	_, err := ParseArgs([]string{"-unknown-flag", "3"})
+// 7. Both flags: -n 3 -p /tmp/foo → iterations=3, project-dir=/tmp/foo.
+func TestNewCommand_BothFlags(t *testing.T) {
+	cfg, err := runNewCommand(t, []string{"-n", "3", "-p", "/tmp/foo"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Iterations != 3 {
+		t.Errorf("expected iterations=3, got %d", cfg.Iterations)
+	}
+	if cfg.ProjectDir != "/tmp/foo" {
+		t.Errorf("expected project-dir=/tmp/foo, got %q", cfg.ProjectDir)
+	}
+}
+
+// 8. Positional args rejected: ["somearg"] → error from cobra.NoArgs.
+func TestNewCommand_PositionalArgRejected(t *testing.T) {
+	cfg := &Config{}
+	cmd := NewCommand(cfg)
+	cmd.SetArgs([]string{"somearg"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for positional arg, got nil")
+	}
+}
+
+// 9. Unknown flags: ["--unknown"] → error.
+func TestNewCommand_UnknownFlag(t *testing.T) {
+	cfg := &Config{}
+	cmd := NewCommand(cfg)
+	cmd.SetArgs([]string{"--unknown"})
+	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error for unknown flag, got nil")
 	}
 }
 
-// T6: large iteration count is accepted
-func TestParseArgs_LargeIterations(t *testing.T) {
-	cfg, err := ParseArgs([]string{"1000", "-project-dir", "/tmp"})
+// 10. --help → Execute() returns (nil, nil) — no workflow started.
+func TestExecute_HelpReturnsNilNil(t *testing.T) {
+	// We can't inject args into Execute(), so we test via NewCommand + cmd.SetArgs.
+	// Execute() itself uses os.Args; test the --help guard behavior via the internal pattern.
+	cfg := &Config{}
+	var ranE bool
+	cmd := newCommandImpl(cfg, &ranE)
+	cmd.SetArgs([]string{"--help"})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error for --help: %v", err)
+	}
+	if ranE {
+		t.Error("RunE should not have executed for --help")
+	}
+}
+
+// 11. --iterations=3 (equals syntax) → iterations=3.
+func TestNewCommand_EqualsSyntax(t *testing.T) {
+	cfg, err := runNewCommand(t, []string{"--iterations=3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Iterations != 3 {
+		t.Errorf("expected iterations=3, got %d", cfg.Iterations)
+	}
+}
+
+// 12. --iterations with no value → error from pflag.
+func TestNewCommand_IterationsNoValue(t *testing.T) {
+	cfg := &Config{}
+	cmd := NewCommand(cfg)
+	cmd.SetArgs([]string{"--iterations"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --iterations with no value, got nil")
+	}
+}
+
+// 13. -n with no value → error from pflag.
+func TestNewCommand_ShortIterationsNoValue(t *testing.T) {
+	cfg := &Config{}
+	cmd := NewCommand(cfg)
+	cmd.SetArgs([]string{"-n"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for -n with no value, got nil")
+	}
+}
+
+// 14. -- extraarg → error from cobra.NoArgs (args after -- are still positional).
+func TestNewCommand_ArgsAfterSeparatorRejected(t *testing.T) {
+	cfg := &Config{}
+	cmd := NewCommand(cfg)
+	cmd.SetArgs([]string{"--", "extraarg"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for positional arg after --, got nil")
+	}
+}
+
+// 15. -n 0 (explicit zero) → iterations=0, equivalent to omitting (until-done mode).
+func TestNewCommand_ExplicitZeroIterations(t *testing.T) {
+	cfg, err := runNewCommand(t, []string{"-n", "0", "-p", "/tmp/foo"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Iterations != 0 {
+		t.Errorf("expected iterations=0, got %d", cfg.Iterations)
+	}
+}
+
+// 16. Large iteration count (1000) → accepted.
+func TestNewCommand_LargeIterations(t *testing.T) {
+	cfg, err := runNewCommand(t, []string{"-n", "1000", "-p", "/tmp/foo"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/ralph-tui/internal/ui/header.go
+++ b/ralph-tui/internal/ui/header.go
@@ -41,8 +41,13 @@ func NewStatusHeader(stepNames [8]string) *StatusHeader {
 
 // SetIteration updates the iteration line string.
 // issueID is the bare number (e.g. "42"); issueTitle is the issue's full title.
+// When total == 0, the iteration line omits the total (unbounded mode).
 func (h *StatusHeader) SetIteration(current, total int, issueID, issueTitle string) {
-	h.IterationLine = fmt.Sprintf("Iteration %d/%d — Issue #%s: %s", current, total, issueID, issueTitle)
+	if total > 0 {
+		h.IterationLine = fmt.Sprintf("Iteration %d/%d — Issue #%s: %s", current, total, issueID, issueTitle)
+	} else {
+		h.IterationLine = fmt.Sprintf("Iteration %d — Issue #%s: %s", current, issueID, issueTitle)
+	}
 }
 
 // SetStepState updates the checkbox label for iteration step idx (0-based, 0-7).

--- a/ralph-tui/internal/ui/header_test.go
+++ b/ralph-tui/internal/ui/header_test.go
@@ -26,6 +26,16 @@ func TestStatusHeader_IterationLine(t *testing.T) {
 	}
 }
 
+func TestStatusHeader_IterationLine_Unbounded(t *testing.T) {
+	h := NewStatusHeader(testStepNames)
+	h.SetIteration(3, 0, "42", "Add widget support")
+
+	want := "Iteration 3 — Issue #42: Add widget support"
+	if h.IterationLine != want {
+		t.Errorf("got %q, want %q", h.IterationLine, want)
+	}
+}
+
 func TestStatusHeader_StepCheckboxStates(t *testing.T) {
 	h := NewStatusHeader(testStepNames)
 

--- a/ralph-tui/internal/workflow/run.go
+++ b/ralph-tui/internal/workflow/run.go
@@ -68,12 +68,12 @@ func Run(executor StepExecutor, header RunHeader, keyHandler *ui.KeyHandler, cfg
 
 	// 3. Iteration loop.
 	iterationsRun := 0
-	for i := 1; i <= cfg.Iterations; i++ {
+	for i := 1; cfg.Iterations == 0 || i <= cfg.Iterations; i++ {
 		issueScript := filepath.Join(cfg.ProjectDir, "scripts", "get_next_issue")
 		issueID, _ := executor.CaptureOutput([]string{issueScript, username})
 
 		if issueID == "" {
-			executor.WriteToLog(fmt.Sprintf("Iteration %d/%d — No issue found. Exiting loop.", i, cfg.Iterations))
+			executor.WriteToLog(fmt.Sprintf("%s — No issue found. Exiting loop.", iterationLabel(i, cfg.Iterations)))
 			break
 		}
 
@@ -87,7 +87,7 @@ func Run(executor StepExecutor, header RunHeader, keyHandler *ui.KeyHandler, cfg
 			header.SetStepState(j, ui.StepPending)
 		}
 
-		executor.WriteToLog(ui.StepSeparator(fmt.Sprintf("Iteration %d/%d — Issue #%s", i, cfg.Iterations, issueID)))
+		executor.WriteToLog(ui.StepSeparator(fmt.Sprintf("%s — Issue #%s", iterationLabel(i, cfg.Iterations), issueID)))
 
 		resolvedSteps, err := buildIterationSteps(cfg.ProjectDir, cfg.Steps, issueID, sha)
 		if err != nil {
@@ -126,6 +126,14 @@ func Run(executor StepExecutor, header RunHeader, keyHandler *ui.KeyHandler, cfg
 
 	// 6. Close executor (sends EOF to log pipe).
 	_ = executor.Close()
+}
+
+// iterationLabel returns "Iteration N/M" for bounded mode or "Iteration N" for unbounded (total == 0).
+func iterationLabel(i, total int) string {
+	if total > 0 {
+		return fmt.Sprintf("Iteration %d/%d", i, total)
+	}
+	return fmt.Sprintf("Iteration %d", i)
 }
 
 func buildIterationSteps(projectDir string, stepsConfig []steps.Step, issueID, sha string) ([]ui.ResolvedStep, error) {

--- a/ralph-tui/internal/workflow/run_test.go
+++ b/ralph-tui/internal/workflow/run_test.go
@@ -1187,9 +1187,9 @@ func TestRun_BoundedModeCapLimitsIterations(t *testing.T) {
 	executor := &fakeExecutor{
 		captureResults: []captureResult{
 			{output: "testuser"},
-			{output: "10"},  // iteration 1
+			{output: "10"}, // iteration 1
 			{output: "sha1"},
-			{output: "20"},  // iteration 2
+			{output: "20"}, // iteration 2
 			{output: "sha2"},
 			// 3rd issue is available but should never be fetched
 			{output: "30"},

--- a/ralph-tui/internal/workflow/run_test.go
+++ b/ralph-tui/internal/workflow/run_test.go
@@ -1024,6 +1024,201 @@ func TestRun_ForceQuit_DuringFinalization_SkipsAllFinalizeSteps(t *testing.T) {
 	}
 }
 
+// --- Unbounded mode tests ---
+
+// TestRun_UnboundedLoopRunsUntilNoIssue verifies that when Iterations == 0,
+// the loop runs until get_next_issue returns empty, then exits.
+func TestRun_UnboundedLoopRunsUntilNoIssue(t *testing.T) {
+	executor := &fakeExecutor{
+		captureResults: []captureResult{
+			{output: "testuser"}, // get_gh_user
+			{output: "10"},       // iteration 1: get_next_issue
+			{output: "sha1"},     // iteration 1: git rev-parse HEAD
+			{output: "20"},       // iteration 2: get_next_issue
+			{output: "sha2"},     // iteration 2: git rev-parse HEAD
+			{output: ""},         // iteration 3: no issue → exit
+		},
+	}
+	header := &fakeRunHeader{}
+	kh := newTestKeyHandler()
+
+	cfg := RunConfig{
+		ProjectDir:    t.TempDir(),
+		Iterations:    0,
+		Steps:         nonClaudeSteps("step1"),
+		FinalizeSteps: nonClaudeSteps("final1"),
+	}
+
+	Run(executor, header, kh, cfg)
+
+	// step1 should have run exactly twice (once per issue), final1 once
+	iterCount := 0
+	for _, call := range executor.runStepCalls {
+		if call.name == "step1" {
+			iterCount++
+		}
+	}
+	if iterCount != 2 {
+		t.Errorf("expected step1 to run 2 times, got %d", iterCount)
+	}
+}
+
+// TestRun_UnboundedLoopRunsFinalizationAfterExhausted verifies finalization
+// runs after the unbounded loop exits when no more issues are found.
+func TestRun_UnboundedLoopRunsFinalizationAfterExhausted(t *testing.T) {
+	executor := &fakeExecutor{
+		captureResults: []captureResult{
+			{output: "testuser"},
+			{output: "10"},
+			{output: "sha1"},
+			{output: "20"},
+			{output: "sha2"},
+			{output: ""},
+		},
+	}
+	header := &fakeRunHeader{}
+	kh := newTestKeyHandler()
+
+	cfg := RunConfig{
+		ProjectDir:    t.TempDir(),
+		Iterations:    0,
+		Steps:         nonClaudeSteps("step1"),
+		FinalizeSteps: nonClaudeSteps("final1"),
+	}
+
+	Run(executor, header, kh, cfg)
+
+	found := false
+	for _, call := range executor.runStepCalls {
+		if call.name == "final1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected finalization to run after unbounded loop exhausted issues")
+	}
+}
+
+// TestRun_UnboundedLoopSetIterationPassesTotalZero verifies that SetIteration
+// is called with total == 0 in unbounded mode.
+func TestRun_UnboundedLoopSetIterationPassesTotalZero(t *testing.T) {
+	executor := &fakeExecutor{
+		captureResults: []captureResult{
+			{output: "testuser"},
+			{output: "10"},
+			{output: "sha1"},
+			{output: ""},
+		},
+	}
+	header := &fakeRunHeader{}
+	kh := newTestKeyHandler()
+
+	cfg := RunConfig{
+		ProjectDir:    t.TempDir(),
+		Iterations:    0,
+		Steps:         nonClaudeSteps("step1"),
+		FinalizeSteps: nonClaudeSteps("final1"),
+	}
+
+	Run(executor, header, kh, cfg)
+
+	if len(header.iterationCalls) == 0 {
+		t.Fatal("expected at least one SetIteration call")
+	}
+	for _, call := range header.iterationCalls {
+		if call.total != 0 {
+			t.Errorf("expected SetIteration total == 0 in unbounded mode, got %d", call.total)
+		}
+	}
+}
+
+// TestRun_UnboundedLoopLogLinesHaveNoTotal verifies log lines use "Iteration N —"
+// format (no "/M") in unbounded mode.
+func TestRun_UnboundedLoopLogLinesHaveNoTotal(t *testing.T) {
+	executor := &fakeExecutor{
+		captureResults: []captureResult{
+			{output: "testuser"},
+			{output: "10"},
+			{output: "sha1"},
+			{output: "20"},
+			{output: "sha2"},
+			{output: ""},
+		},
+	}
+	header := &fakeRunHeader{}
+	kh := newTestKeyHandler()
+
+	cfg := RunConfig{
+		ProjectDir:    t.TempDir(),
+		Iterations:    0,
+		Steps:         nonClaudeSteps("step1"),
+		FinalizeSteps: nonClaudeSteps("final1"),
+	}
+
+	Run(executor, header, kh, cfg)
+
+	for _, line := range executor.logLines {
+		if strings.Contains(line, "Iteration 1/") || strings.Contains(line, "Iteration 2/") {
+			t.Errorf("unbounded log line should not contain total, got: %q", line)
+		}
+	}
+
+	found1 := false
+	found2 := false
+	for _, line := range executor.logLines {
+		if strings.Contains(line, "Iteration 1 —") {
+			found1 = true
+		}
+		if strings.Contains(line, "Iteration 2 —") {
+			found2 = true
+		}
+	}
+	if !found1 {
+		t.Error("expected log line containing 'Iteration 1 —'")
+	}
+	if !found2 {
+		t.Error("expected log line containing 'Iteration 2 —'")
+	}
+}
+
+// TestRun_BoundedModeCapLimitsIterations verifies that when more issues are
+// available than Iterations, the loop stops at the cap.
+func TestRun_BoundedModeCapLimitsIterations(t *testing.T) {
+	executor := &fakeExecutor{
+		captureResults: []captureResult{
+			{output: "testuser"},
+			{output: "10"},  // iteration 1
+			{output: "sha1"},
+			{output: "20"},  // iteration 2
+			{output: "sha2"},
+			// 3rd issue is available but should never be fetched
+			{output: "30"},
+			{output: "sha3"},
+		},
+	}
+	header := &fakeRunHeader{}
+	kh := newTestKeyHandler()
+
+	cfg := RunConfig{
+		ProjectDir:    t.TempDir(),
+		Iterations:    2,
+		Steps:         nonClaudeSteps("step1"),
+		FinalizeSteps: nonClaudeSteps("final1"),
+	}
+
+	Run(executor, header, kh, cfg)
+
+	iterCount := 0
+	for _, call := range executor.runStepCalls {
+		if call.name == "step1" {
+			iterCount++
+		}
+	}
+	if iterCount != 2 {
+		t.Errorf("expected exactly 2 iterations with bounded cap, got %d", iterCount)
+	}
+}
+
 // TestRun_StepsPendingSetBeforeIteration verifies that all step indices are
 // set to StepPending before the first StepActive call in each iteration.
 func TestRun_StepsPendingSetBeforeIteration(t *testing.T) {

--- a/ralph-tui/internal/workflow/run_test.go
+++ b/ralph-tui/internal/workflow/run_test.go
@@ -1219,6 +1219,26 @@ func TestRun_BoundedModeCapLimitsIterations(t *testing.T) {
 	}
 }
 
+// --- iterationLabel unit tests ---
+
+// TestIterationLabel_BoundedMode verifies "Iteration N/M" format when total > 0.
+func TestIterationLabel_BoundedMode(t *testing.T) {
+	cases := []struct {
+		i, total int
+		want     string
+	}{
+		{1, 3, "Iteration 1/3"},
+		{2, 0, "Iteration 2"},
+		{1, 1, "Iteration 1/1"},
+	}
+	for _, c := range cases {
+		got := iterationLabel(c.i, c.total)
+		if got != c.want {
+			t.Errorf("iterationLabel(%d, %d) = %q, want %q", c.i, c.total, got, c.want)
+		}
+	}
+}
+
 // TestRun_StepsPendingSetBeforeIteration verifies that all step indices are
 // set to StepPending before the first StepActive call in each iteration.
 func TestRun_StepsPendingSetBeforeIteration(t *testing.T) {
@@ -1249,5 +1269,221 @@ func TestRun_StepsPendingSetBeforeIteration(t *testing.T) {
 		if !pendingBeforeActive[idx] {
 			t.Errorf("expected StepPending for index %d before first StepActive", idx)
 		}
+	}
+}
+
+// --- Additional unbounded mode tests ---
+
+// TestRun_UnboundedQuitFromOrchestrateClosesAndSkipsFinalization verifies that
+// when Orchestrate returns ActionQuit during an unbounded-mode iteration, Run
+// closes the executor and skips finalization and the completion summary.
+func TestRun_UnboundedQuitFromOrchestrateClosesAndSkipsFinalization(t *testing.T) {
+	actions := make(chan ui.StepAction, 10)
+	actions <- ui.ActionQuit
+	kh := ui.NewKeyHandler(func() {}, actions)
+
+	executor := &fakeExecutor{
+		captureResults: oneIssueResults("testuser", "42", "abc123"),
+		runStepErrors:  []error{errors.New("step failed")},
+	}
+	header := &fakeRunHeader{}
+
+	cfg := RunConfig{
+		ProjectDir:    t.TempDir(),
+		Iterations:    0,
+		Steps:         nonClaudeSteps("iter-step"),
+		FinalizeSteps: nonClaudeSteps("final1"),
+	}
+
+	Run(executor, header, kh, cfg)
+
+	if !executor.closed {
+		t.Error("expected executor to be closed on quit in unbounded mode")
+	}
+	for _, call := range executor.runStepCalls {
+		if call.name == "final1" {
+			t.Error("finalization step should not have run after iteration quit in unbounded mode")
+		}
+	}
+	for _, line := range executor.logLines {
+		if strings.Contains(line, "Ralph completed") {
+			t.Errorf("expected no completion summary on quit, found: %q", line)
+		}
+	}
+}
+
+// TestRun_UnboundedCompletionSummaryShowsActualCount verifies that after the
+// unbounded loop processes N issues and exits, the completion summary reports N.
+func TestRun_UnboundedCompletionSummaryShowsActualCount(t *testing.T) {
+	executor := &fakeExecutor{
+		captureResults: []captureResult{
+			{output: "testuser"},
+			{output: "10"},   // iteration 1: issue found
+			{output: "sha1"}, // iteration 1: sha
+			{output: "20"},   // iteration 2: issue found
+			{output: "sha2"}, // iteration 2: sha
+			{output: ""},     // iteration 3: no issue → exit
+		},
+	}
+	header := &fakeRunHeader{}
+	kh := newTestKeyHandler()
+
+	cfg := RunConfig{
+		ProjectDir:    t.TempDir(),
+		Iterations:    0,
+		Steps:         nonClaudeSteps("step1"),
+		FinalizeSteps: nonClaudeSteps("final1"),
+	}
+
+	Run(executor, header, kh, cfg)
+
+	found := false
+	for _, line := range executor.logLines {
+		if strings.Contains(line, "2 iteration(s)") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected completion summary with '2 iteration(s)' in unbounded mode, got %v", executor.logLines)
+	}
+}
+
+// TestRun_UnboundedForceQuitClosesExecutorAndReturns verifies that when
+// ForceQuit is called before Run starts, Run terminates cleanly and closes
+// the executor in unbounded mode.
+func TestRun_UnboundedForceQuitClosesExecutorAndReturns(t *testing.T) {
+	actions := make(chan ui.StepAction, 10)
+	kh := ui.NewKeyHandler(func() {}, actions)
+
+	executor := &fakeExecutor{
+		captureResults: oneIssueResults("testuser", "42", "abc123"),
+	}
+	header := &fakeRunHeader{}
+
+	cfg := RunConfig{
+		ProjectDir:    t.TempDir(),
+		Iterations:    0,
+		Steps:         nonClaudeSteps("step1", "step2"),
+		FinalizeSteps: nonClaudeSteps("final1"),
+	}
+
+	kh.ForceQuit()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		Run(executor, header, kh, cfg)
+	}()
+
+	select {
+	case <-done:
+		// Run returned cleanly after ForceQuit.
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return after ForceQuit in unbounded mode")
+	}
+
+	if !executor.closed {
+		t.Error("expected executor.Close() to be called after ForceQuit in unbounded mode")
+	}
+}
+
+// TestRun_UnboundedBuildIterationStepsErrorLogsAndContinuesToFinalization
+// verifies that when buildIterationSteps fails in unbounded mode, Run logs
+// "Error preparing steps", breaks the loop, runs finalization, and reports
+// 0 iterations in the summary.
+func TestRun_UnboundedBuildIterationStepsErrorLogsAndContinuesToFinalization(t *testing.T) {
+	executor := &fakeExecutor{
+		captureResults: []captureResult{
+			{output: "testuser"},
+			{output: "42"},
+			{output: "abc123"},
+		},
+	}
+	header := &fakeRunHeader{}
+	kh := newTestKeyHandler()
+
+	claudeStep := steps.Step{
+		Name:       "bad-claude",
+		IsClaude:   true,
+		Model:      "some-model",
+		PromptFile: "nonexistent.txt",
+	}
+
+	cfg := RunConfig{
+		ProjectDir:    t.TempDir(),
+		Iterations:    0,
+		Steps:         []steps.Step{claudeStep},
+		FinalizeSteps: nonClaudeSteps("final1"),
+	}
+
+	Run(executor, header, kh, cfg)
+
+	foundErr := false
+	for _, line := range executor.logLines {
+		if strings.Contains(line, "Error preparing steps") {
+			foundErr = true
+		}
+	}
+	if !foundErr {
+		t.Errorf("expected 'Error preparing steps' in log, got %v", executor.logLines)
+	}
+
+	ranFinal := false
+	for _, call := range executor.runStepCalls {
+		if call.name == "final1" {
+			ranFinal = true
+		}
+	}
+	if !ranFinal {
+		t.Error("expected finalization to run after buildIterationSteps error in unbounded mode")
+	}
+
+	found0 := false
+	for _, line := range executor.logLines {
+		if strings.Contains(line, "0 iteration(s)") {
+			found0 = true
+		}
+	}
+	if !found0 {
+		t.Errorf("expected '0 iteration(s)' in completion summary, got %v", executor.logLines)
+	}
+}
+
+// TestRun_UnboundedNoIssueFoundLogFormat verifies the "No issue found" log line
+// uses "Iteration N" format (no "/M") in unbounded mode.
+func TestRun_UnboundedNoIssueFoundLogFormat(t *testing.T) {
+	executor := &fakeExecutor{
+		captureResults: []captureResult{
+			{output: "testuser"},
+			{output: "10"},   // iteration 1: issue found
+			{output: "sha1"}, // iteration 1: sha
+			{output: "20"},   // iteration 2: issue found
+			{output: "sha2"}, // iteration 2: sha
+			{output: ""},     // iteration 3: no issue → exit
+		},
+	}
+	header := &fakeRunHeader{}
+	kh := newTestKeyHandler()
+
+	cfg := RunConfig{
+		ProjectDir:    t.TempDir(),
+		Iterations:    0,
+		Steps:         nonClaudeSteps("step1"),
+		FinalizeSteps: nonClaudeSteps("final1"),
+	}
+
+	Run(executor, header, kh, cfg)
+
+	foundNoIssue := false
+	for _, line := range executor.logLines {
+		if strings.Contains(line, "Iteration 3") && strings.Contains(line, "No issue found") {
+			foundNoIssue = true
+		}
+		if strings.Contains(line, "Iteration 3/") {
+			t.Errorf("unbounded 'no issue' log line should not contain total, got: %q", line)
+		}
+	}
+	if !foundNoIssue {
+		t.Errorf("expected log line with 'Iteration 3' and 'No issue found', got %v", executor.logLines)
 	}
 }


### PR DESCRIPTION
## Summary

Migrates ralph-tui CLI argument parsing from Go's stdlib `flag` package to [spf13/cobra](https://github.com/spf13/cobra), and in doing so changes the iteration model: instead of requiring a positional `<iterations>` argument, iterations is now an optional `--iterations` / `-n` flag that defaults to `0`, which activates a new **until-done mode** that loops until `get_next_issue` returns no more work.

### Behavioral changes

| Aspect | Before | After |
|---|---|---|
| Run command | `ralph-tui 3 -project-dir /tmp` | `ralph-tui -n 3 -p /tmp` |
| Iterations arg | Positional, required, must be `> 0` | Flag `--iterations`/`-n`, optional, default `0` |
| Project dir flag | `-project-dir` (long only) | `--project-dir`/`-p` (POSIX long+short) |
| `ralph-tui` with no args | Error: `missing required argument: iterations` | Runs until `get_next_issue` finds no more issues |
| `-n 0` | Rejected (`iterations must be > 0`) | Valid — explicit until-done mode |
| Negative iterations | Rejected | Rejected: `cli: --iterations must be a non-negative integer` |
| Positional args | Required (`iterations`) | Rejected via `cobra.NoArgs` |
| Error output | `error: <msg>` | `error: <msg>\nRun 'ralph-tui --help' for usage.` |
| Iteration display | `Iteration 3/5 — Issue #42` | Bounded: `Iteration 3/5 — Issue #42` • Unbounded: `Iteration 3 — Issue #42` |

### Mechanism

- `cli.ParseArgs` and the custom `reorderArgs` workaround (which patched around stdlib `flag`'s "stop at first positional" limit) are deleted. `cli.Execute()` replaces them: it builds a cobra command via an unexported `newCommandImpl(cfg, ranE *bool)` that populates `cfg` through `RunE` and sets `*ranE = true`. This sentinel lets `Execute` distinguish a clean `--help` exit (RunE never ran → return `(nil, nil)`) from a successful parse (`(cfg, nil)`) and from an error (`(nil, err)`).
- `main.go` guards the `(nil, nil)` case and exits 0 without starting the workflow. The workflow loop in `workflow/run.go` changes from `for i := 1; i <= cfg.Iterations; i++` to `for i := 1; cfg.Iterations == 0 || i <= cfg.Iterations; i++`; the existing early-exit when `get_next_issue` is empty becomes the sole stop condition in unbounded mode.
- A new pure helper `iterationLabel(i, total int) string` centralizes the `"Iteration N/M"` vs `"Iteration N"` format decision, used by both the log separator and the "No issue found" message. `StatusHeader.SetIteration` applies the same conditional when `total == 0`.
- Cobra configuration uses `SilenceErrors: true`, `SilenceUsage: true`, and `cobra.NoArgs`; `main.go` prints errors with a help hint to compensate for the silenced usage output.
- An ADR (`docs/adr/20260409135303-cobra-cli-framework.md`) records the rationale for choosing cobra over kong and urfave/cli (long-term ecosystem stability over boilerplate reduction). The completed plan (`docs/plans/cobra-cli-option-parsing.md`) documents the decision trail and one accepted risk: unbounded mode has no safety cap and relies on the user's Ctrl-C if `get_next_issue` fails to make progress.

## Key file changes

| File | Change |
|------|--------|
| `ralph-tui/internal/cli/args.go` | Delete `ParseArgs` and `reorderArgs`; add `NewCommand`, `Execute`, and `newCommandImpl` backed by cobra. Keep `resolveProjectDir` and `Config` (now `Iterations int` where `0 = until done`). Error messages use `cli:` prefix. |
| `ralph-tui/internal/workflow/run.go` | Replace bounded `for` with `cfg.Iterations == 0 \|\| i <= cfg.Iterations`. Add `iterationLabel(i, total)` helper; route log separator and "No issue found" messages through it. Pass `cfg.Iterations` (may be 0) through to `SetIteration`. |
| `ralph-tui/cmd/ralph-tui/main.go` | Call `cli.Execute()` instead of `cli.ParseArgs(os.Args[1:])`; add `if cfg == nil { os.Exit(0) }` for the `--help` path; append `Run 'ralph-tui --help' for usage.` to error output. |
| `ralph-tui/internal/ui/header.go` | `SetIteration` now emits `Iteration N/M — …` when `total > 0` and `Iteration N — …` when `total == 0` (unbounded). `IterationLine` comment documents both forms. |
| `ralph-tui/go.mod` | Add `github.com/spf13/cobra v1.10.2` (transitive: `pflag v1.0.9`, `mousetrap v1.1.0`). |
| `docs/adr/20260409135303-cobra-cli-framework.md` | New ADR: cobra vs kong vs urfave/cli; decision prioritizes ecosystem stability. |
| `docs/plans/cobra-cli-option-parsing.md` | New completed plan (status: done) with all decisions, accepted risks, and agent validation findings. |
| `docs/features/cli-configuration.md` | Rewrite for cobra: new flag table, Execute/NewCommand documentation, updated error scenarios (removes "missing iterations", adds "positional arg rejected"), expanded test case list (10 → 16). |
| `docs/coding-standards/go-patterns.md` | Delete "Reorder args" section; add "Extract conditional format strings to a named pure helper" (iterationLabel) and two cobra patterns (shared impl via `newCommandImpl` + ranE sentinel, nil-config guard). |
| `docs/coding-standards/testing.md` | Add "Test names must match actual test scope" (driven by `TestIterationLabel` covering both bounded and unbounded). |
| ... | +11 more files (README.md, CLAUDE.md, architecture.md, tui-display.md, workflow-orchestration.md, project-discovery.md, plans/ralph-tui.md, go.sum, and 3 test files — see Test Files Changed) |

## Key test scenario changes

- ✅ `cli.NewCommand`: `--iterations`/`-n` long and short forms parse to `Iterations` int; `--iterations=3` equals syntax works via pflag
- ✅ `cli.NewCommand`: `--iterations -1` rejected with `"--iterations must be a non-negative integer"`
- ✅ `cli.NewCommand`: `--project-dir`/`-p` long and short forms populate `ProjectDir`; both flags combine correctly
- ✅ `cli.NewCommand`: no flags → `Iterations=0`, `ProjectDir` resolved from executable (non-empty)
- ✅ `cli.NewCommand`: `-n 0` explicit zero is accepted (until-done mode); large `-n 1000` accepted
- ✅ `cli.NewCommand`: positional arg (`"somearg"`) rejected by `cobra.NoArgs`; `-- extraarg` also rejected
- ✅ `cli.NewCommand`: unknown flag rejected; `-n`/`--iterations` with no value rejected by pflag
- ✅ `cli.newCommandImpl` + `--help`: `RunE` is not invoked (`ranE=false`), caller can treat as clean exit
- ✅ `ui.StatusHeader.SetIteration`: `total > 0` → `"Iteration N/M — Issue #… : …"`; `total == 0` → `"Iteration N — Issue #… : …"` (no total)
- ✅ `workflow.iterationLabel`: returns `"Iteration N/M"` for bounded, `"Iteration N"` for unbounded (`total == 0`)
- ✅ `workflow.Run` bounded mode: stops after exactly `cfg.Iterations` loops even when more issues are available
- ✅ `workflow.Run` unbounded mode (`Iterations: 0`): runs until `get_next_issue` returns empty, then proceeds to finalization; `SetIteration` calls pass `total=0`; log lines use `"Iteration N"` format (no total)

### Test Files Changed

| File | Change |
|------|--------|
| `ralph-tui/internal/cli/args_test.go` | Rewrite: 11 `TestParseArgs_*` cases replaced with 16 `TestNewCommand_*`/`TestExecute_*` cases driven by `cmd.SetArgs()` + `cmd.Execute()` against a fresh `Config`. New cases cover short flags, equals syntax, explicit `-n 0`, empty flag values, and `--help` via `newCommandImpl`. |
| `ralph-tui/internal/ui/header_test.go` | Add case for `SetIteration(3, 0, …)` producing `"Iteration 3 — Issue #…"` (no total). |
| `ralph-tui/internal/workflow/run_test.go` | New file (+431 lines): `fakeExecutor`, `fakeRunHeader`, and unit tests for `iterationLabel`, bounded-mode regression (3 issues available, `Iterations: 2` → only 2 run), and unbounded-mode scenarios (2 issues then empty, finalization still runs, total=0 propagates to `SetIteration`, log lines use "Iteration N"). |

## Test Plan

- [ ] `cd ralph-tui && go test -race ./...` passes
- [ ] `make ci` passes (test, lint, format, vet, vulncheck, mod-tidy, build)
- [ ] `./bin/ralph-tui --help` prints usage and exits 0
- [ ] `./bin/ralph-tui -n 1` runs exactly one iteration against a repo with ≥1 `ralph`-labeled issue
- [ ] `./bin/ralph-tui` (no flags) runs until `get_next_issue` returns empty, then proceeds to finalization
- [ ] `./bin/ralph-tui -n 0` behaves identically to no-flag invocation
- [ ] `./bin/ralph-tui -n -1` prints `cli: --iterations must be a non-negative integer` followed by the help hint, exits 1
- [ ] `./bin/ralph-tui somearg` is rejected by `cobra.NoArgs` with a help hint, exits 1
- [ ] `./bin/ralph-tui --unknown` prints pflag error plus help hint, exits 1
- [ ] `./bin/ralph-tui -p /tmp/foo -n 1` uses `/tmp/foo` as project dir (without invoking `resolveProjectDir`)
- [ ] Header displays `Iteration N/M — Issue #…` in bounded mode and `Iteration N — Issue #…` in unbounded mode
- [ ] Running as a symlinked binary still resolves the real project dir (symlink-safe `resolveProjectDir` untouched)