### PR TITLE
fixing issues with working dir vs executing dir

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,9 @@ Intermediate files (`progress.txt`, `deferred.txt`, `test-plan.md`, `code-review
 
 ## Key Design Decisions
 
-- Ralph is invoked **from the target repo** — all subprocesses inherit that cwd
-- The project directory is resolved from the executable path via `os.Executable()` + `filepath.EvalSymlinks`
+- Two distinct directories, captured separately at startup:
+  - **ProjectDir (install dir)** — where ralph-tui's bundled `ralph-steps.json`, `scripts/`, `prompts/`, and `ralph-art.txt` live. Resolved from the executable path via `os.Executable()` + `filepath.EvalSymlinks`, or overridden with `--project-dir` / `-p`. Anchors `{{PROJECT_DIR}}` template substitution and relative script-path resolution.
+  - **WorkingDir (target repo)** — the user's shell CWD captured via `os.Getwd()` at startup. Governs subprocess `cmd.Dir` (so `gh`, `git`, `claude` operate against the target repo) and the `logs/` output location.
 - The `get_next_issue` script sorts open issues and picks the lowest number
 - Non-claude steps (`close_gh_issue`, `git push`) run as shell commands defined in JSON configs
 

--- a/docs/features/cli-configuration.md
+++ b/docs/features/cli-configuration.md
@@ -155,21 +155,28 @@ func resolveProjectDir() (string, error) {
 
 This is why `go run` does not work — it places the binary in a temporary directory. Use `go build` and run the compiled binary, or pass `--project-dir` explicitly.
 
-### ProjectDir Fan-Out
+### ProjectDir vs WorkingDir
 
-After parsing, `Config.ProjectDir` is distributed to five consumers in `main.go`:
+ralph-tui distinguishes two directories that are often conflated:
 
-| Consumer | Path Resolved |
-|----------|---------------|
-| `logger.NewLogger(projectDir)` | `{projectDir}/logs/ralph-*.log` |
-| `steps.LoadSteps(projectDir)` | `{projectDir}/ralph-steps.json` |
-| `validator.Validate(projectDir)` | Validates `ralph-steps.json` relative to `{projectDir}` |
-| `workflow.NewRunner(log, projectDir)` | Sets `cmd.Dir` for all subprocesses |
-| `workflow.RunConfig.ProjectDir` | Scripts, prompt files, command resolution |
+- **ProjectDir** (install dir) — where ralph-tui's bundled `ralph-steps.json`, `scripts/`, `prompts/`, and `ralph-art.txt` live. Resolved from the executable path by default, or overridden by `--project-dir` / `-p`.
+- **WorkingDir** — the user's shell CWD captured at startup via `os.Getwd()`. Governs subprocess `cmd.Dir` (so `gh`, `git`, and `claude` run against the target repo) and log file location (so `logs/` land alongside the work).
+
+Consumers in `main.go`:
+
+| Consumer | Dir | Path Resolved |
+|----------|-----|---------------|
+| `logger.NewLogger(workingDir)` | WorkingDir | `{workingDir}/logs/ralph-*.log` |
+| `steps.LoadSteps(projectDir)` | ProjectDir | `{projectDir}/ralph-steps.json` |
+| `validator.Validate(projectDir)` | ProjectDir | Validates `ralph-steps.json` relative to `{projectDir}` |
+| `workflow.NewRunner(log, workingDir)` | WorkingDir | Sets `cmd.Dir` for all subprocesses |
+| `workflow.RunConfig.ProjectDir` | ProjectDir | Scripts, prompt files, `{{PROJECT_DIR}}` variable |
 
 Within the workflow, `ProjectDir` anchors two path-resolution mechanisms:
 - `{projectDir}/prompts/{promptFile}` — prompt files via `steps.BuildPrompt` (for Claude steps)
 - Relative script paths from step config — resolved against `projectDir` by `ResolveCommand` (e.g. `scripts/get_gh_user`, `scripts/close_gh_issue`); not hardcoded in `Run()`
+
+The `{{PROJECT_DIR}}` template variable resolves to `ProjectDir` (install dir) — e.g., `{{PROJECT_DIR}}/ralph-art.txt` in `ralph-steps.json` refers to the bundled banner file alongside the binary.
 
 ## Error Handling
 

--- a/docs/features/file-logging.md
+++ b/docs/features/file-logging.md
@@ -8,7 +8,7 @@ A concurrent-safe file logger that writes timestamped, context-prefixed lines to
 
 ## Overview
 
-- Writes to `logs/ralph-YYYY-MM-DD-HHMMSS.log` under the project directory
+- Writes to `logs/ralph-YYYY-MM-DD-HHMMSS.log` under the working directory (the user's shell CWD at startup)
 - Each line is prefixed with a timestamp, optional iteration context, and step name
 - Protected by `sync.Mutex` for concurrent writes from multiple scanner goroutines
 - Uses `bufio.Writer` for buffered I/O with explicit flush on close
@@ -71,8 +71,8 @@ type Logger struct {
 `NewLogger` creates the `logs/` directory if needed and opens a timestamped log file:
 
 ```go
-func NewLogger(projectDir string) (*Logger, error) {
-    logsDir := filepath.Join(projectDir, "logs")
+func NewLogger(workingDir string) (*Logger, error) {
+    logsDir := filepath.Join(workingDir, "logs")
     if err := os.MkdirAll(logsDir, 0o700); err != nil {
         return nil, fmt.Errorf("logger: could not create logs directory: %w", err)
     }
@@ -167,7 +167,7 @@ func (l *Logger) Close() error {
 
 - [Architecture Overview](../architecture.md) — Data flow showing logger alongside the `sendLine` streaming path
 - [Subprocess Execution & Streaming](subprocess-execution.md) — How scanner goroutines write to the logger
-- [CLI & Configuration](cli-configuration.md) — How ProjectDir determines the log file location
+- [CLI & Configuration](cli-configuration.md) — How the working directory is captured at startup and governs the log file location
 - [Workflow Orchestration](workflow-orchestration.md) — Where log context (iteration number) is set during the run loop
 - [Concurrency](../coding-standards/concurrency.md) — Coding standards for mutex-protected shared writers
 - [Error Handling](../coding-standards/error-handling.md) — Coding standards for bufio.Writer error surfacing and package-prefixed errors

--- a/ralph-tui/cmd/ralph-tui/main.go
+++ b/ralph-tui/cmd/ralph-tui/main.go
@@ -28,7 +28,58 @@ func stepNames(ss []steps.Step) []string {
 	return names
 }
 
+// services bundles the dependencies wired from cfg and the captured working
+// directory. Split out so tests can verify each constructor receives the
+// correct dir (logger/runner bound to workingDir; steps/validator bound to
+// cfg.ProjectDir).
+type services struct {
+	log      *logger.Logger
+	runner   *workflow.Runner
+	stepFile steps.StepFile
+}
+
+// newServices wires the logger, runner, and step file. workingDir is the
+// shell CWD captured at startup and governs subprocess cmd.Dir and log file
+// location. cfg.ProjectDir is the install dir (where ralph-steps.json,
+// scripts/, prompts/ live). On validation failure, errors are written to
+// stderr and ok=false is returned.
+func newServices(cfg *cli.Config, workingDir string) (s *services, ok bool) {
+	log, err := logger.NewLogger(workingDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return nil, false
+	}
+
+	stepFile, err := steps.LoadSteps(cfg.ProjectDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		_ = log.Close()
+		return nil, false
+	}
+
+	if validationErrs := validator.Validate(cfg.ProjectDir); len(validationErrs) > 0 {
+		for _, ve := range validationErrs {
+			fmt.Fprintln(os.Stderr, ve.Error())
+		}
+		fmt.Fprintf(os.Stderr, "%d validation error(s)\n", len(validationErrs))
+		_ = log.Close()
+		return nil, false
+	}
+
+	return &services{
+		log:      log,
+		runner:   workflow.NewRunner(log, workingDir),
+		stepFile: stepFile,
+	}, true
+}
+
 func main() {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "main: could not resolve working dir: %v\n", err)
+		os.Exit(1)
+	}
+
 	cfg, err := cli.Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\nRun 'ralph-tui --help' for usage.\n", err)
@@ -38,29 +89,13 @@ func main() {
 		os.Exit(0)
 	}
 
-	log, err := logger.NewLogger(cfg.ProjectDir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	svc, ok := newServices(cfg, workingDir)
+	if !ok {
 		os.Exit(1)
 	}
-
-	stepFile, err := steps.LoadSteps(cfg.ProjectDir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		_ = log.Close()
-		os.Exit(1)
-	}
-
-	if validationErrs := validator.Validate(cfg.ProjectDir); len(validationErrs) > 0 {
-		for _, ve := range validationErrs {
-			fmt.Fprintln(os.Stderr, ve.Error())
-		}
-		fmt.Fprintf(os.Stderr, "%d validation error(s)\n", len(validationErrs))
-		_ = log.Close()
-		os.Exit(1)
-	}
-
-	runner := workflow.NewRunner(log, cfg.ProjectDir)
+	log := svc.log
+	stepFile := svc.stepFile
+	runner := svc.runner
 
 	actions := make(chan ui.StepAction, 10)
 	keyHandler := ui.NewKeyHandler(runner.Terminate, actions)

--- a/ralph-tui/cmd/ralph-tui/main_test.go
+++ b/ralph-tui/cmd/ralph-tui/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/mxriverlynn/pr9k/ralph-tui/internal/cli"
 	"github.com/mxriverlynn/pr9k/ralph-tui/internal/steps"
 )
 
@@ -37,4 +40,74 @@ func TestStepNames_Multiple(t *testing.T) {
 			t.Errorf("index %d: want %q, got %q", i, want[i], got[i])
 		}
 	}
+}
+
+// writeMinimalStepFile creates a minimal valid ralph-steps.json under dir so
+// steps.LoadSteps and validator.Validate succeed without requiring real
+// prompts or scripts.
+func writeMinimalStepFile(t *testing.T, dir string) {
+	t.Helper()
+	content := `{
+		"initialize": [],
+		"iteration": [
+			{ "name": "noop", "isClaude": false, "command": ["true"] }
+		],
+		"finalize": []
+	}`
+	if err := os.WriteFile(filepath.Join(dir, "ralph-steps.json"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestNewServices_BindsLoggerAndRunnerToWorkingDir verifies that newServices
+// wires the logger and runner to workingDir, not to cfg.ProjectDir. This
+// guards against reintroducing the bug where subprocess cmd.Dir and log
+// output were mistakenly bound to the install dir.
+func TestNewServices_BindsLoggerAndRunnerToWorkingDir(t *testing.T) {
+	installDir := t.TempDir()
+	workingDir := t.TempDir()
+	writeMinimalStepFile(t, installDir)
+
+	cfg := &cli.Config{ProjectDir: installDir}
+	svc, ok := newServices(cfg, workingDir)
+	if !ok {
+		t.Fatal("newServices returned ok=false")
+	}
+	defer func() { _ = svc.log.Close() }()
+
+	// Logger creates logs/ under workingDir, not installDir.
+	if _, err := os.Stat(filepath.Join(workingDir, "logs")); err != nil {
+		t.Errorf("expected logs/ under workingDir, got error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "logs")); !os.IsNotExist(err) {
+		t.Errorf("logs/ should NOT exist under installDir; Stat err=%v", err)
+	}
+
+	// Runner subprocess cmd.Dir is workingDir, not installDir.
+	out, err := svc.runner.CaptureOutput([]string{"sh", "-c", "pwd"})
+	if err != nil {
+		t.Fatalf("CaptureOutput: %v", err)
+	}
+	wantDir, _ := filepath.EvalSymlinks(workingDir)
+	gotDir, _ := filepath.EvalSymlinks(out)
+	if gotDir != wantDir {
+		t.Errorf("runner cmd.Dir: want %q, got %q", wantDir, gotDir)
+	}
+}
+
+// TestNewServices_LoadsStepsFromProjectDir verifies that newServices reads
+// ralph-steps.json from cfg.ProjectDir (install dir), not workingDir.
+func TestNewServices_LoadsStepsFromProjectDir(t *testing.T) {
+	installDir := t.TempDir()
+	workingDir := t.TempDir()
+	writeMinimalStepFile(t, installDir)
+	// Deliberately do NOT write ralph-steps.json in workingDir: if the wiring
+	// is wrong, LoadSteps will fail.
+
+	cfg := &cli.Config{ProjectDir: installDir}
+	svc, ok := newServices(cfg, workingDir)
+	if !ok {
+		t.Fatal("newServices returned ok=false; ralph-steps.json should have been loaded from ProjectDir")
+	}
+	_ = svc.log.Close()
 }

--- a/ralph-tui/internal/logger/logger.go
+++ b/ralph-tui/internal/logger/logger.go
@@ -20,9 +20,10 @@ type Logger struct {
 }
 
 // NewLogger creates a new Logger that writes to logs/ralph-YYYY-MM-DD-HHMMSS.log
-// under projectDir. The logs/ directory is created if it does not exist.
-func NewLogger(projectDir string) (*Logger, error) {
-	logsDir := filepath.Join(projectDir, "logs")
+// under workingDir (the user's shell CWD at startup). The logs/ directory is
+// created if it does not exist.
+func NewLogger(workingDir string) (*Logger, error) {
+	logsDir := filepath.Join(workingDir, "logs")
 	if err := os.MkdirAll(logsDir, 0o700); err != nil {
 		return nil, fmt.Errorf("logger: could not create logs directory: %w", err)
 	}

--- a/ralph-tui/internal/version/version.go
+++ b/ralph-tui/internal/version/version.go
@@ -4,4 +4,4 @@
 package version
 
 // Version is the current ralph-tui release version.
-const Version = "0.2.2"
+const Version = "0.2.3"

--- a/ralph-tui/internal/workflow/workflow.go
+++ b/ralph-tui/internal/workflow/workflow.go
@@ -38,7 +38,9 @@ type Runner struct {
 
 // NewRunner creates a Runner that streams subprocess output through the sendLine
 // callback (set via SetSender) and to the file logger. workingDir is set as
-// cmd.Dir for every subprocess.
+// cmd.Dir for every subprocess and must be the user's shell CWD (the target
+// repo being operated on), not the install dir where ralph-tui's bundled
+// ralph-steps.json, scripts/, and prompts/ live.
 //
 // NewRunner initializes sendLine to a sentinel that panics with a descriptive
 // message so that missing-wire bugs (forgetting to call SetSender before

--- a/ralph-tui/internal/workflow/workflow_test.go
+++ b/ralph-tui/internal/workflow/workflow_test.go
@@ -211,6 +211,47 @@ func TestRunStep_AllLinesArrivedBeforeCmdWait(t *testing.T) {
 	_ = log.Close()
 }
 
+// TestRunStep_UsesWorkingDir verifies RunStep sets cmd.Dir to the runner's
+// workingDir (shell CWD), not the install dir. Mirrors the equivalent test
+// for CaptureOutput.
+func TestRunStep_UsesWorkingDir(t *testing.T) {
+	workingDir := t.TempDir()
+	logDir := t.TempDir()
+	log, err := logger.NewLogger(logDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = log.Close() }()
+
+	r := NewRunner(log, workingDir)
+	var mu sync.Mutex
+	var captured []string
+	r.SetSender(func(line string) {
+		mu.Lock()
+		captured = append(captured, line)
+		mu.Unlock()
+	})
+
+	if err := r.RunStep("pwd-step", []string{"sh", "-c", "pwd"}); err != nil {
+		t.Fatalf("RunStep: %v", err)
+	}
+
+	wantDir, _ := filepath.EvalSymlinks(workingDir)
+	mu.Lock()
+	defer mu.Unlock()
+	found := false
+	for _, line := range captured {
+		got, err := filepath.EvalSymlinks(line)
+		if err == nil && got == wantDir {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected RunStep cmd.Dir=%q in captured output, got %v", wantDir, captured)
+	}
+}
+
 // Integration tests
 
 func TestRunStep_IntegrationStdoutInPipeAndLogFile(t *testing.T) {


### PR DESCRIPTION
## Summary

Splits the single conflated "project dir" into two distinct directories captured separately at startup, so subprocesses and log files follow the user's shell CWD instead of the ralph-tui install dir.

### Problem

Previously, `Config.ProjectDir` (resolved from the executable path via `os.Executable()`) was fanned out to five consumers, including `logger.NewLogger` and `workflow.NewRunner`. This meant `logs/` was written next to the binary and subprocesses (`gh`, `git`, `claude`) ran with `cmd.Dir` set to the install dir — not the target repo the user invoked ralph-tui from.

### Solution

Capture `workingDir` via `os.Getwd()` at the top of `main()` and route it separately from `cfg.ProjectDir`:

| Consumer | Dir | Path Resolved |
|----------|-----|---------------|
| `logger.NewLogger(workingDir)` | WorkingDir | `{workingDir}/logs/ralph-*.log` |
| `workflow.NewRunner(log, workingDir)` | WorkingDir | `cmd.Dir` for all subprocesses |
| `steps.LoadSteps(cfg.ProjectDir)` | ProjectDir | `{projectDir}/ralph-steps.json` |
| `validator.Validate(cfg.ProjectDir)` | ProjectDir | Validates relative to `{projectDir}` |
| `workflow.RunConfig.ProjectDir` | ProjectDir | Scripts, prompts, `{{PROJECT_DIR}}` |

Wiring is extracted into a `newServices(cfg, workingDir)` helper in `main.go` so the two-dir contract is testable. Bumps version to `0.2.3`.

## Key file changes

| File | Change |
|------|--------|
| `ralph-tui/cmd/ralph-tui/main.go` | Capture `workingDir` via `os.Getwd()`; extract `newServices` helper that binds logger/runner to `workingDir` and steps/validator to `cfg.ProjectDir` |
| `ralph-tui/internal/logger/logger.go` | Rename `NewLogger` parameter `projectDir` → `workingDir`; logs now land under the shell CWD |
| `ralph-tui/internal/workflow/workflow.go` | Doc-comment on `NewRunner` clarifying `workingDir` must be shell CWD, not install dir |
| `ralph-tui/internal/version/version.go` | Bump `Version` to `0.2.3` |
| `CLAUDE.md` | Rewrite "Key Design Decisions" to describe the ProjectDir/WorkingDir split |
| `docs/features/cli-configuration.md` | Replace "ProjectDir Fan-Out" section with "ProjectDir vs WorkingDir" table and `{{PROJECT_DIR}}` note |
| `docs/features/file-logging.md` | Update all references from projectDir to workingDir |

## Key test scenario changes

- ✅ `newServices` creates `logs/` under `workingDir`, not under `installDir`
- ✅ Runner subprocesses run with `cmd.Dir == workingDir` (verified by capturing `pwd` output)
- ✅ `newServices` loads `ralph-steps.json` from `cfg.ProjectDir`, not `workingDir`
- ✅ `RunStep` sets `cmd.Dir` to the runner's `workingDir` (mirrors the existing `CaptureOutput` test)

### Test Files Changed

| File | Change |
|------|--------|
| `ralph-tui/cmd/ralph-tui/main_test.go` | New tests for `newServices` verifying logger/runner bind to `workingDir` and steps load from `ProjectDir` |
| `ralph-tui/internal/workflow/workflow_test.go` | New `TestRunStep_UsesWorkingDir` confirming `RunStep` honors the runner's `workingDir` |

## Test Plan

- [ ] `make ci` passes (test, lint, format, vet, vulncheck, mod-tidy, build)
- [ ] `cd ralph-tui && go test -race ./...` passes
- [ ] Build with `make build`; invoke `./bin/ralph-tui` from a target repo and confirm `logs/` is created in the target repo's CWD, not alongside the binary
- [ ] Confirm `gh`, `git`, and `claude` subprocesses run against the target repo (e.g. `get_next_issue` finds issues in the target repo's remote)
- [ ] Confirm `{{PROJECT_DIR}}/ralph-art.txt` still resolves to the banner bundled with the binary