### PR TITLE
Confirm actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ See [`docs/architecture.md`](docs/architecture.md) for detailed architectural do
 - [`docs/features/subprocess-execution.md`](docs/features/subprocess-execution.md) — Subprocess lifecycle management with real-time io.Pipe streaming and sendLine callback (SetSender), graceful SIGTERM/SIGKILL termination, and output capture
 - [`docs/features/workflow-orchestration.md`](docs/features/workflow-orchestration.md) — The Run loop driving iterations and finalization, and the Orchestrate step sequencer with interactive error recovery
 - [`docs/features/tui-display.md`](docs/features/tui-display.md) — Pointer-mutable status header with checkbox-based step progress and step separator formatting
-- [`docs/features/keyboard-input.md`](docs/features/keyboard-input.md) — Four-mode keyboard state machine (Normal/Error/QuitConfirm/Quitting) and channel-based action dispatch
+- [`docs/features/keyboard-input.md`](docs/features/keyboard-input.md) — Six-mode keyboard state machine (Normal/Error/QuitConfirm/NextConfirm/Done/Quitting) and channel-based action dispatch
 - [`docs/features/signal-handling.md`](docs/features/signal-handling.md) — OS signal handling (SIGINT/SIGTERM) triggering clean shutdown via ForceQuit
 - [`docs/features/file-logging.md`](docs/features/file-logging.md) — Concurrent-safe timestamped file logger with millisecond-precision filenames and `RunStamp()` accessor for artifact directory naming
 - [`docs/features/variable-state.md`](docs/features/variable-state.md) — `VarTable` with persistent and iteration scopes, built-in variables, and phase-based resolution
@@ -105,6 +105,7 @@ Problem-focused guides for users running ralph-tui against their own projects. W
 - [`docs/how-to/building-custom-workflows.md`](docs/how-to/building-custom-workflows.md) — How to create custom step sequences, add prompts, and mix Claude and shell steps
 - [`docs/how-to/variable-output-and-injection.md`](docs/how-to/variable-output-and-injection.md) — How `{{VAR}}` tokens are resolved from the VarTable into prompts and commands, and how steps pass data via files
 - [`docs/how-to/capturing-step-output.md`](docs/how-to/capturing-step-output.md) — How to use `captureAs` to bind a step's stdout to a variable for use in later steps, including initialize-vs-iteration scoping
+- [`docs/how-to/passing-environment-variables.md`](docs/how-to/passing-environment-variables.md) — How to forward host environment variables into the Docker sandbox via the `env` field in `ralph-steps.json`
 - [`docs/how-to/breaking-out-of-the-loop.md`](docs/how-to/breaking-out-of-the-loop.md) — Using `breakLoopIfEmpty` to exit the iteration loop dynamically when a capture step returns nothing
 - [`docs/how-to/recovering-from-step-failures.md`](docs/how-to/recovering-from-step-failures.md) — Error mode keyboard controls (`c` continue, `r` retry, `q` quit) and when to use each
 - [`docs/how-to/quitting-gracefully.md`](docs/how-to/quitting-gracefully.md) — The `q`/`y` confirmation flow, Escape cancel, SIGINT/SIGTERM, `Quitting...` feedback, and exit codes

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint format vet vulncheck mod-tidy ci
+.PHONY: build test lint format format-check vet vulncheck mod-tidy ci
 
 build:
 	rm -rf bin
@@ -16,6 +16,9 @@ lint:
 	cd ralph-tui && golangci-lint run
 
 format:
+	cd ralph-tui && gofmt -w .
+
+format-check:
 	@cd ralph-tui && unformatted=$$(gofmt -l .); \
 	if [ -n "$$unformatted" ]; then \
 		echo "Files not formatted:"; \
@@ -39,4 +42,4 @@ mod-tidy:
 		exit 1; \
 	fi
 
-ci: test lint format vet vulncheck mod-tidy build
+ci: test lint format-check vet vulncheck mod-tidy build

--- a/docs/adr/20260411070907-bubble-tea-tui-framework.md
+++ b/docs/adr/20260411070907-bubble-tea-tui-framework.md
@@ -80,7 +80,7 @@ We specifically reject tview because its lack of first-class window-title suppor
 
 **Neutral:**
 
-- The four-mode keyboard state machine (`ModeNormal`, `ModeError`, `ModeQuitConfirm`, `ModeQuitting`) carries over unchanged as data; only its dispatch plumbing changes
+- The keyboard state machine carries over as data; only its dispatch plumbing changes. (At migration time, this was four modes: `ModeNormal`, `ModeError`, `ModeQuitConfirm`, `ModeQuitting`. Post-migration, `ModeNextConfirm` and `ModeDone` were added — see `docs/features/keyboard-input.md` for the current six-mode design.)
 - The 500-line log cap and auto-scroll-on-tail behavior remain, but are enforced in our Model rather than a widget flag
 - File logging in `internal/workflow/workflow.go` is independent of the TUI library and is not affected by this change
 
@@ -92,7 +92,7 @@ We specifically reject tview because its lack of first-class window-title suppor
 |------|---------|
 | `ralph-tui/cmd/ralph-tui/main.go` | Program entry point — constructs `tea.NewProgram(model, tea.WithMouseCellMotion(), tea.WithAltScreen(), tea.WithoutSignalHandler())`, wires the drain goroutine and signal handler, and calls `program.Run()`. |
 | `ralph-tui/internal/ui/header.go` | `StatusHeader` struct with per-cell Lip Gloss color arrays. Mutations are applied only via `headerModel.apply()` on the Bubble Tea Update goroutine. |
-| `ralph-tui/internal/ui/ui.go` | Four-mode keyboard state machine `KeyHandler`. The `Mode` enum and transition rules are unchanged; dispatch is handled by `keysModel.Update(msg tea.KeyMsg)` in `keys.go`. |
+| `ralph-tui/internal/ui/ui.go` | Keyboard state machine `KeyHandler`. The `Mode` enum started with four modes at migration time; `ModeNextConfirm` and `ModeDone` were added later (now six modes). Dispatch is handled by `keysModel.Update(msg tea.KeyMsg)` in `keys.go`. |
 | `ralph-tui/internal/ui/orchestrate.go` | Step sequencer that sends `StepAction` over the `Actions` channel. Interface unchanged. |
 | `ralph-tui/internal/workflow/workflow.go` | Subprocess runner using a `sendLine` callback (installed via `SetSender`) to forward lines non-blockingly into a buffered channel; a drain goroutine in `main.go` coalesces them into `LogLinesMsg` values sent via `program.Send`. No `io.Pipe` or `LogReader`. |
 | `ralph-tui/go.mod` | `github.com/kungfusheep/glyph` removed; `bubbletea`, `lipgloss`, `bubbles` added. |

--- a/docs/adr/20260413160000-require-docker-sandbox.md
+++ b/docs/adr/20260413160000-require-docker-sandbox.md
@@ -53,7 +53,7 @@ aligns the runtime with the upstream trust model.
    - Pros: the safety guarantee is binary and unconditional; no code path
      where the invariant is accidentally bypassed.
    - Cons: users who do not have Docker installed must install it before
-     ralph-tui works at all; adds a startup preflight check; `create-sandbox`
+     ralph-tui works at all; adds a startup preflight check; `sandbox create`
      subcommand is required to pull and verify the image before first use.
 
 2. **Make Docker optional; fall back to direct invocation.**
@@ -82,7 +82,7 @@ Adopt **Option 1**: Docker is an unconditional runtime requirement. No
 - The startup preflight (see `docs/features/preflight.md`) checks for Docker
   reachability and the sandbox image before the TUI starts, so users get a
   clear actionable error rather than a mid-run failure.
-- The `ralph-tui create-sandbox` subcommand (see `docs/features/create-sandbox.md`)
+- The `ralph-tui sandbox create` subcommand (see `docs/features/sandbox-subcommand.md`)
   provides a guided setup path that pulls the image and runs a smoke test,
   minimizing the friction of the new dependency.
 - The target audience (developers running an AI-driven coding loop against a
@@ -101,7 +101,7 @@ Adopt **Option 1**: Docker is an unconditional runtime requirement. No
 
 **Negative:**
 
-- Users without Docker must install it before ralph-tui works. `create-sandbox`
+- Users without Docker must install it before ralph-tui works. `sandbox create`
   provides a guided path, but the install itself is outside ralph-tui's control.
 - A stopped or crashed Docker daemon after startup causes the next claude step
   to fail visibly — recoverable, but disruptive to an unattended run.
@@ -114,7 +114,7 @@ Adopt **Option 1**: Docker is an unconditional runtime requirement. No
   threat class.
 - The image reference is tag-only (`docker/sandbox-templates:claude-code`, not
   pinned by digest). Users get upstream updates by re-running
-  `ralph-tui create-sandbox --force`. This trades reproducibility for upgrade
+  `ralph-tui sandbox create --force`. This trades reproducibility for upgrade
   ergonomics — the same trust model as `npm i -g @anthropic-ai/claude-code`.
 
 ## Notes
@@ -127,17 +127,17 @@ Adopt **Option 1**: Docker is an unconditional runtime requirement. No
 | `ralph-tui/internal/sandbox/terminator.go` | `NewTerminator` — `docker kill` via cidfile for clean termination |
 | `ralph-tui/internal/preflight/docker.go` | `CheckDocker` — startup check that Docker CLI and daemon are reachable |
 | `ralph-tui/internal/preflight/run.go` | `Run` — orchestrates all preflight checks and returns structured results |
-| `ralph-tui/cmd/ralph-tui/create_sandbox.go` | `create-sandbox` subcommand — guided image pull and smoke test |
+| `ralph-tui/cmd/ralph-tui/sandbox_create.go` | `sandbox create` subcommand — guided image pull and smoke test |
 
 ### Related Docs
 
 - [Docker Sandbox Feature Doc](../features/docker-sandbox.md) — architecture,
   mount layout, env allowlist, cidfile termination, and residual risks
 - [Setting Up Docker Sandbox](../how-to/setting-up-docker-sandbox.md) — user-facing
-  guide: install Docker, run `create-sandbox`, authenticate profile
+  guide: install Docker, run `sandbox create`, authenticate profile
 - [Preflight Feature Doc](../features/preflight.md) — startup validation
   including Docker reachability and sandbox image presence
-- [Create Sandbox Feature Doc](../features/create-sandbox.md) — `create-sandbox`
+- [Sandbox Subcommand Feature Doc](../features/sandbox-subcommand.md) — `sandbox create`
   subcommand implementation
 - [Sandbox Design Plan](../plans/docker-sandbox/design.md) — full design
   rationale, threat model (§3), and architectural decisions (§4)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,38 +124,47 @@ Built with [Bubble Tea](https://github.com/charmbracelet/bubbletea) + [Lip Gloss
                   ┌─────────────┐
                   │ ModeNormal  │
                   │             │
-                  │ n → skip    │
-                  │ q ──────────┼──────┐
-                  └──────┬──────┘      │
-                         │             │
-                   step fails          │
-                         │             │
-                         ▼             ▼
-                  ┌─────────────┐  ┌───────────────────┐
-                  │ ModeError   │  │ ModeQuitConfirm   │
-                  │             │  │                   │
-                  │ c → continue│  │ y → ModeQuitting  │
-                  │ r → retry   │  │     + ForceQuit   │
-                  │ q ──────────┼─▶│ n, Esc → prevMode │
-                  └─────────────┘  └─────────┬─────────┘
-                                             │ y
-                                             ▼
-                                    ┌─────────────────┐
-                                    │  ModeQuitting   │
-                                    │                 │
-                                    │ footer shows    │
-                                    │ "Quitting..."   │
-                                    │ (terminal)      │
-                                    └─────────────────┘
+                  │ n ──────────┼──────────────────────┐
+                  │ q ──────────┼──────┐               │
+                  └──────┬──────┘      │               │
+                         │             │               │
+                   step fails          │               │
+                         │             │               ▼
+                         ▼             ▼       ┌────────────────────┐
+                  ┌─────────────┐  ┌──────────────────┐│ ModeNextConfirm  │
+                  │ ModeError   │  │ ModeQuitConfirm  ││                  │
+                  │             │  │                  ││ y → cancel step  │
+                  │ c → continue│  │ y → ModeQuitting ││     + prevMode   │
+                  │ r → retry   │  │     + ForceQuit  ││ n, Esc → prevMode│
+                  │ q ──────────┼─▶│ n, Esc → prevMode│└────────────────────┘
+                  └─────────────┘  └────────┬─────────┘
+                                            │ y
+                                            ▼
+                                   ┌─────────────────┐
+                                   │  ModeQuitting   │
+                                   │                 │
+                                   │ footer shows    │
+                                   │ "Quitting..."   │
+                                   │ (terminal)      │
+                                   └─────────────────┘
+
+  Normal completion:
+    → Run returns after writing the completion summary
+    → workflow goroutine enters ModeDone ("q quit" footer)
+    → user reviews output, then presses q → y to exit
+
+                  ┌─────────────┐
+                  │  ModeDone   │
+                  │             │
+                  │ q ──────────┼──▶ ModeQuitConfirm
+                  │ (only key)  │    → y → tea.QuitMsg
+                  └─────────────┘
 
   OS Signal (SIGINT/SIGTERM):
     → KeyHandler.ForceQuit()
     → cancel subprocess + inject ActionQuit
-    (unified with the QuitConfirm 'y' path)
-
-  Normal completion:
-    → Run returns after writing the completion summary
-    → workflow goroutine restores the terminal and os.Exit(0)s
+    (unified with the QuitConfirm 'y' path;
+     active in all modes including ModeDone)
 ```
 
 ## Features
@@ -190,13 +199,13 @@ The top-level `Run` function drives the entire workflow in three config-defined 
 
 A Bubble Tea `Model` assembled row-by-row in `Model.View()` as a hand-built rounded frame (no `lipgloss.Border` wrapper, so the two internal horizontal rules can use `├─┤` T-junction glyphs that visually connect to the `│` side borders). The current iteration/issue is embedded into the top-border title — `Power-Ralph.9000 — Iteration N/M — Issue #<id>` in bounded mode, or `Power-Ralph.9000 — Iteration N — Issue #<id>` when running unbounded (`--iterations 0`); the same string is set as the OS window title via `tea.SetWindowTitle`. The app name `Power-Ralph.9000` (from the `AppTitle` constant) renders green and the iteration detail after the ` — ` separator renders white. Step progress displays as a dynamic grid of rows, each holding `HeaderCols` (4) checkboxes, sized at startup to fit the largest phase. Each step shows as `[ ]` (pending), `[▸]` (active), `[✓]` (done), `[✗]` (failed), or `[-]` (skipped). `SetPhaseSteps` swaps the header to a new phase's step names at the start of each phase (initialize, iteration, finalize). State updates are sent as typed messages via `HeaderProxy` (which calls `program.Send`) so header mutations never race with the Bubble Tea Update goroutine. The log body is rendered in white and is also structured: `log.go` helpers produce full-width `PhaseBanner` headings, per-iteration `StepSeparator` lines, per-step `StepStartBanner` headings, `CaptureLog` lines for `captureAs` bindings, and the final `CompletionSummary` — all sized via `ui.TerminalWidth()` with an 80-column fallback. D23 heartbeat: when no stream-json event arrives for ≥15 s during an active claude step, the iteration title appends `  ⋯ thinking (Ns)`; the suffix updates in-place each second and is cleared as soon as the next event arrives. The heartbeat reader is installed via `StatusHeader.SetHeartbeatReader(runner)` in `main.go` before the model is constructed; a separate 1-second ticker goroutine in `main.go` dispatches `HeartbeatTickMsg` via `program.Send` — `Model.Init()` returns nil and the ticker is not owned by the Bubble Tea event loop. `Model.Update()` delegates `HeartbeatTickMsg` to `StatusHeader.HandleHeartbeatTick()`. The `Runner` in `workflow.go` implements `HeartbeatReader` by exposing `HeartbeatSilence() (time.Duration, bool)` under `processMu`.
 
-**Package:** `internal/ui/` (`header.go`, `log.go`, `log_panel.go`, `messages.go`, `model.go`, `orchestrate.go`, `terminal.go`)
+**Package:** `internal/ui/` (`header.go`, `keys.go`, `log.go`, `log_panel.go`, `messages.go`, `model.go`, `orchestrate.go`, `terminal.go`)
 
 ### [Keyboard Input & Error Recovery](features/keyboard-input.md)
 
-A four-mode state machine (`ModeNormal`, `ModeError`, `ModeQuitConfirm`, `ModeQuitting`) that routes keypresses and communicates user decisions to the orchestration goroutine via a buffered `Actions` channel. In normal mode, `n` skips the current step and `q` enters quit confirmation. In error mode (entered when a step fails), `c` continues, `r` retries, and `q` enters quit confirmation. In quit-confirm mode, `y` flips to `ModeQuitting` (footer shows `Quitting...`) and calls `ForceQuit`; `n` or `<Escape>` cancel. When the workflow finishes normally, `Run` returns on its own and the workflow goroutine exits the process directly — no "press any key to exit" state. Each mode displays its own shortcut bar text.
+A six-mode state machine (`ModeNormal`, `ModeError`, `ModeQuitConfirm`, `ModeNextConfirm`, `ModeDone`, `ModeQuitting`) that routes keypresses and communicates user decisions to the orchestration goroutine via a buffered `Actions` channel. In normal mode, `n` enters a skip-confirmation prompt (`ModeNextConfirm`) and `q` enters quit confirmation. In error mode (entered when a step fails), `c` continues, `r` retries, and `q` enters quit confirmation. In quit-confirm mode, `y` flips to `ModeQuitting` (footer shows `Quitting...`) and calls `ForceQuit`; `n` or `<Escape>` cancel. In next-confirm mode, `y` cancels the subprocess and returns to the previous mode; `n` or `<Escape>` cancel the skip. When the workflow finishes normally, the TUI enters `ModeDone` (footer shows `q quit`) so the user can review output before quitting via `q` → `y`. Each mode displays its own shortcut bar text.
 
-**Package:** `internal/ui/` (`ui.go`)
+**Package:** `internal/ui/` (`ui.go`, `keys.go`)
 
 ### [Signal Handling & Shutdown](features/signal-handling.md)
 
@@ -259,8 +268,11 @@ cmd/ralph-tui/main.go
     └── internal/workflow      (subprocess execution, run loop)
             ├── internal/claudestream  (stream-json pipeline)
             ├── internal/logger
+            ├── internal/preflight
+            ├── internal/sandbox
             ├── internal/steps
-            └── internal/ui
+            ├── internal/ui
+            └── internal/vars
 
 internal/claudestream          (stream-json parsing, rendering, aggregation)
     (no internal dependencies)
@@ -280,6 +292,7 @@ internal/claudestream          (stream-json parsing, rendering, aggregation)
 - **How-To Guides:**
   - [Building Custom Workflows](how-to/building-custom-workflows.md) — Creating custom step sequences, adding prompts, mixing Claude and shell steps
   - [Variable Output & Injection](how-to/variable-output-and-injection.md) — Variable injection into prompts/commands and file-based data passing between steps
+  - [Passing Environment Variables](how-to/passing-environment-variables.md) — Forwarding host env vars into the Docker sandbox via the `env` field
 - [ralph-tui Plan](plans/ralph-tui.md) — Original specification with acceptance criteria, verification checklist, and design rationale
 - [Project Discovery](project-discovery.md) — Repository-level attributes: languages, frameworks, tooling, commands, and configuration
 - **Coding Standards** — Conventions that govern ralph-tui implementation:

--- a/docs/coding-standards/api-design.md
+++ b/docs/coding-standards/api-design.md
@@ -42,10 +42,18 @@ func BuildPrompt(workflowDir string, step Step, vt *vars.VarTable, phase vars.Ph
 
 ## Use named constants for template placeholder strings
 
-Template placeholder strings shared between config JSON and Go code (e.g., `{{ISSUE_ID}}`) should be named constants. As the number of placeholders grows, scattered string literals become a maintenance hazard.
+Template placeholder strings shared between config JSON and Go code (e.g., `{{ISSUE_ID}}`) should be named constants or centralized in a registry. As the number of placeholders grows, scattered string literals become a maintenance hazard. In this codebase, the `reservedNames` map in `internal/vars/vars.go` serves as the single registry of built-in variable names:
 
 ```go
-const issueIDPlaceholder = "{{ISSUE_ID}}"
+var reservedNames = map[string]bool{
+    "WORKFLOW_DIR": true,
+    "PROJECT_DIR":  true,
+    "MAX_ITER":     true,
+    "ITER":         true,
+    "STEP_NUM":     true,
+    "STEP_COUNT":   true,
+    "STEP_NAME":    true,
+}
 ```
 
 ## Adapter types for interface narrowing

--- a/docs/coding-standards/concurrency.md
+++ b/docs/coding-standards/concurrency.md
@@ -123,49 +123,49 @@ for _, step := range steps {
 
 ## Signal path and completion path must converge cleanly
 
-When a Bubble Tea TUI app has two paths that cause the program to stop — a signal path (SIGINT/SIGTERM) and a normal completion path — both must trigger clean shutdown via `program.Quit()` or `program.Kill()`. Missing one path leaves the program running or leaves the terminal in a bad state.
+When a Bubble Tea TUI app has two paths that cause the program to stop — a signal path (SIGINT/SIGTERM) and a normal completion path — both must trigger clean shutdown via the TUI's quit mechanisms. Missing one path leaves the program running or leaves the terminal in a bad state.
 
 ```go
-// Signal path — triggered by SIGINT/SIGTERM
+// Signal path — triggered by SIGINT/SIGTERM; remains active during ModeDone
 go func() {
+    <-sigChan
+    close(signaled)
+    keyHandler.ForceQuit()
     select {
-    case <-sigChan:
-        keyHandler.ForceQuit()
-        select {
-        case <-workflowDone:
-        case <-time.After(2 * time.Second):
-            program.Kill() // force if workflow doesn't unwind
-        }
     case <-workflowDone:
+    case <-time.After(2 * time.Second):
     }
+    program.Kill() // always kill — safe even if workflow already finished
 }()
 
-// Normal completion path — workflow goroutine calls program.Quit() itself
+// Normal completion path — workflow goroutine enters ModeDone; user quits via q→y
 go func() {
     defer close(workflowDone)
     _ = workflow.Run(...)
-    program.Quit() // signals Bubble Tea to stop its event loop
+    _ = log.Close()
+    close(lineCh)
+    keyHandler.SetMode(ui.ModeDone) // TUI stays alive for user review
 }()
 ```
 
-The workflow goroutine calls `program.Quit()` on normal completion. The signal path calls `ForceQuit()` (which unwinds orchestration) and waits for the workflow goroutine with a 2-second grace period before `program.Kill()`.
+The workflow goroutine enters `ModeDone` on normal completion — the TUI stays alive so the user can review output and quit via `q` → `y` (which sends `tea.QuitMsg`). The signal handler goroutine blocks unconditionally on `<-sigChan` (no `case <-workflowDone` escape hatch) so it remains active during `ModeDone` — a SIGINT during the done screen still triggers `ForceQuit` + `program.Kill()`, restoring the terminal cleanly.
 
 ## Wait for background goroutines after program.Run() returns
 
-After `program.Run()` returns (Bubble Tea's blocking event loop), use a `select` with a timeout to wait for the workflow goroutine to finish cleanup. The program may stop before the workflow goroutine flushes logs or closes channels.
+After `program.Run()` returns (Bubble Tea's blocking event loop), deregister signal notifications and use a `select` with a timeout to wait for the workflow goroutine to finish cleanup. The program may stop before the workflow goroutine flushes logs or closes channels — particularly in the mid-workflow quit path, where `handleQuitConfirm`'s `tea.QuitMsg` causes `program.Run()` to return immediately after `ForceQuit`, racing the goroutine's `log.Close()` and `close(lineCh)`.
 
 ```go
 _, runErr := program.Run()
-// ...
+signal.Stop(sigChan) // deregister after TUI exits cleanly
 
-// program.Run() may return before the workflow goroutine closes workflowDone.
+// Wait for the workflow goroutine to finish cleanup (log flush, channel close).
 select {
 case <-workflowDone:
-case <-time.After(2 * time.Second):
+case <-time.After(4 * time.Second):
 }
 ```
 
-Choose a timeout long enough for cleanup (flushing logs, deregistering signals) but short enough that a hung goroutine does not stall the process indefinitely.
+The 4-second timeout exceeds the 3-second `terminateGracePeriod` in `runner.Terminate()` plus buffer for `log.Close()` and `close(lineCh)` — this prevents `os.Exit` from firing while SIGTERM→SIGKILL is still in progress during a mid-workflow quit.
 
 ## Unexported field + mutex-protected getter for shortcut bar text
 

--- a/docs/coding-standards/concurrency.md
+++ b/docs/coding-standards/concurrency.md
@@ -67,7 +67,7 @@ const (
     ActionContinue
     ActionQuit
 )
-actions := make(chan StepAction, 1)
+actions := make(chan StepAction, 10)
 ```
 
 ## Non-blocking send for signal-safe channel writes
@@ -166,26 +166,6 @@ case <-time.After(4 * time.Second):
 ```
 
 The 4-second timeout exceeds the 3-second `terminateGracePeriod` in `runner.Terminate()` plus buffer for `log.Close()` and `close(lineCh)` — this prevents `os.Exit` from firing while SIGTERM→SIGKILL is still in progress during a mid-workflow quit.
-
-## Unexported field + mutex-protected getter for shortcut bar text
-
-The shortcut bar string is written by mode transitions (on the Update goroutine) and read by `View()` (also on the Update goroutine via `ShortcutLine()`). Keep it unexported and expose it only through a mutex-protected getter so that signal handlers and test goroutines can also read it safely without races:
-
-```go
-type KeyHandler struct {
-    mu           sync.Mutex
-    shortcutLine string
-}
-
-// ShortcutLine is safe to call from any goroutine.
-func (h *KeyHandler) ShortcutLine() string {
-    h.mu.Lock()
-    defer h.mu.Unlock()
-    return h.shortcutLine
-}
-```
-
-In the Bubble Tea architecture, `View()` calls `ShortcutLine()` directly via the mutex-protected getter. All mode mutations happen on the Update goroutine, which serializes writes naturally; the mutex guards reads from other goroutines (signal handlers, test code).
 
 ## Prime the channel before entering a blocking receive
 

--- a/docs/coding-standards/go-patterns.md
+++ b/docs/coding-standards/go-patterns.md
@@ -42,13 +42,16 @@ See [testing.md](testing.md) — `runtime.Caller(0)` is the correct way to resol
 When a function transforms a slice (e.g., replacing template variables), allocate a new slice rather than mutating the input. Callers often reuse the original slice across multiple iterations.
 
 ```go
-func ResolveCommand(projectDir string, command []string, issueID string) []string {
+func ResolveCommand(workflowDir string, command []string, vt *vars.VarTable, phase vars.Phase) []string {
     if len(command) == 0 {
         return command
     }
     result := make([]string, len(command))
-    copy(result, command)
-    // ... transform result ...
+    for i, arg := range command {
+        substituted, _ := vars.Substitute(arg, vt, phase)
+        result[i] = substituted
+    }
+    // ... resolve script paths ...
     return result
 }
 ```
@@ -67,18 +70,30 @@ scanner.Buffer(buf, 256*1024)
 
 When the same conditional formatting decision (e.g., bounded vs. unbounded, singular vs. plural) appears in multiple log or UI call sites, extract it as a named unexported function rather than repeating the condition inline. This makes the formatting logic independently testable and keeps the condition in one place.
 
-In this codebase the `substitute` helper in `header.go` handles this for iteration/phase lines via template strings (`iterationHeaderBoundedFormat`, `iterationHeaderUnboundedFormat`, etc.), so the conditional logic lives in `RenderIterationLine` and the formatting in the templates.
+In this codebase the `substitute` helper in `header.go` handles this for initialize and finalize lines via template strings, so the conditional logic lives in the render method and the formatting in the templates. `RenderIterationLine` uses `strings.Builder` with `fmt.Fprintf` directly because its format varies more dynamically (optional issue suffix):
 
 ```go
-// Phase-specific render methods each select the right template and call substitute:
+// RenderInitializeLine and RenderFinalizeLine use substitute with template constants:
+func (h *StatusHeader) RenderInitializeLine(stepNum, stepCount int, stepName string) {
+    h.IterationLine = substitute(initializeHeaderFormat, map[string]string{
+        "STEP_NUM":   strconv.Itoa(stepNum),
+        "STEP_COUNT": strconv.Itoa(stepCount),
+        "STEP_NAME":  stepName,
+    })
+}
+
+// RenderIterationLine uses strings.Builder for its dynamic format:
 func (h *StatusHeader) RenderIterationLine(iter, maxIter int, issueID string) {
-    vals := map[string]string{"ITER": strconv.Itoa(iter), "ISSUE_ID": issueID}
+    var b strings.Builder
     if maxIter > 0 {
-        vals["MAX_ITER"] = strconv.Itoa(maxIter)
-        h.IterationLine = substitute(iterationHeaderBoundedFormat, vals)
+        fmt.Fprintf(&b, "Iteration %d/%d", iter, maxIter)
     } else {
-        h.IterationLine = substitute(iterationHeaderUnboundedFormat, vals)
+        fmt.Fprintf(&b, "Iteration %d", iter)
     }
+    if issueID != "" {
+        fmt.Fprintf(&b, " — Issue #%s", issueID)
+    }
+    h.IterationLine = b.String()
 }
 ```
 

--- a/docs/coding-standards/testing.md
+++ b/docs/coding-standards/testing.md
@@ -205,20 +205,12 @@ If step 3 is deferred (because the production caller doesn't exist yet), documen
 When you add a new blocking channel receive (`<-ch`) to code already covered by tests, every test that exercises that code path must send one additional signal to unblock it. Failure to do so causes the test to hang.
 
 ```go
-// Before: Run() has no blocking receive — newTestKeyHandler injects no signals
-func newTestKeyHandler() *ui.KeyHandler { ... }
-
-// After: Run() added <-keyHandler.Actions as its completion handoff —
-// inject ActionQuit asynchronously so it unblocks without racing the
-// non-blocking pre-step drains that Orchestrate performs.
+// newTestKeyHandler creates a KeyHandler with a buffered channel and a no-op
+// cancel function. The channel capacity (10) absorbs any actions injected by
+// the orchestration loop (non-blocking drains) without deadlocking.
 func newTestKeyHandler() *ui.KeyHandler {
     actions := make(chan ui.StepAction, 10)
-    kh := ui.NewKeyHandler(func() {}, actions)
-    go func() {
-        time.Sleep(10 * time.Millisecond)
-        actions <- ui.ActionQuit
-    }()
-    return kh
+    return ui.NewKeyHandler(func() {}, actions)
 }
 ```
 

--- a/docs/coding-standards/versioning.md
+++ b/docs/coding-standards/versioning.md
@@ -31,10 +31,10 @@ When you are about to make a change, ask: "does this break one of the four items
 
 ## `0.y.z` — initial development
 
-The current release is `0.3.1`. Per semver §4, while MAJOR is `0`, **anything may change at any time** and the public API is not considered stable. For this repo, that means:
+The current release is `0.4.1`. Per semver §4, while MAJOR is `0`, **anything may change at any time** and the public API is not considered stable. For this repo, that means:
 
-- Backwards-incompatible changes to the CLI surface or `ralph-steps.json` schema during `0.y.z` bump the **MINOR** (e.g. `0.3.1` → `0.4.0`), not the major.
-- Backwards-compatible additions and bug fixes both bump the **PATCH** (e.g. `0.3.1` → `0.3.2`).
+- Backwards-incompatible changes to the CLI surface or `ralph-steps.json` schema during `0.y.z` bump the **MINOR** (e.g. `0.4.1` → `0.5.0`), not the major.
+- Backwards-compatible additions and bug fixes both bump the **PATCH** (e.g. `0.4.1` → `0.4.2`).
 - The first `1.0.0` release is the commitment that the four "public API" items above are stable and will be governed by the full semver rules going forward. Do not bump to `1.0.0` casually — it should be a deliberate decision with a corresponding entry in the repo's plans or ADRs.
 
 ## How to bump the version

--- a/docs/features/docker-sandbox.md
+++ b/docs/features/docker-sandbox.md
@@ -54,8 +54,8 @@ docker run                                              \
   --init                                                \
   --cidfile <TMP>/ralph-<UNIQUE>.cid                    \
   -u <UID>:<GID>                                        \
-  -v <PROJECT_DIR>:/home/agent/workspace                \
-  -v <PROFILE_DIR>:/home/agent/.claude                  \
+  --mount type=bind,source=<PROJECT_DIR>,target=/home/agent/workspace  \
+  --mount type=bind,source=<PROFILE_DIR>,target=/home/agent/.claude   \
   -w /home/agent/workspace                              \
   -e CLAUDE_CONFIG_DIR=/home/agent/.claude              \
   [-e ANTHROPIC_API_KEY]                                \
@@ -79,8 +79,8 @@ docker run                                              \
 - `--init` — install tini as PID 1 so SIGTERM is forwarded to claude and zombie processes are reaped.
 - `--cidfile <tmp>/ralph-<unique>.cid` — capture the container ID so `Terminate()` can call `docker kill <cid>` rather than signaling the host docker CLI process (which would orphan the container). The cidfile path is unique per step under `os.TempDir()`.
 - `-u <UID>:<GID>` — run as the invoking host user. Files written to the bind-mounted repo are owned by the host user, so subsequent shell steps (`git`, `gh`) work without permission errors.
-- `-v <PROJECT_DIR>:/home/agent/workspace` — bind-mount the target repo. `<PROJECT_DIR>` is the `--project-dir` value (default: `os.Getwd()` + `filepath.EvalSymlinks`). The workflow bundle (`<WORKFLOW_DIR>`) is NOT mounted.
-- `-v <PROFILE_DIR>:/home/agent/.claude` — bind-mount the Claude profile (read-write so OAuth token refresh works).
+- `--mount type=bind,source=<PROJECT_DIR>,target=/home/agent/workspace` — bind-mount the target repo. `<PROJECT_DIR>` is the `--project-dir` value (default: `os.Getwd()` + `filepath.EvalSymlinks`). The `--mount` syntax is used instead of `-v` to avoid argument injection via colons in path names. The workflow bundle (`<WORKFLOW_DIR>`) is NOT mounted.
+- `--mount type=bind,source=<PROFILE_DIR>,target=/home/agent/.claude` — bind-mount the Claude profile (read-write so OAuth token refresh works).
 - `-w /home/agent/workspace` — explicit working directory; matches the bind-mount so relative paths inside the container correspond to real host paths.
 - `-e CLAUDE_CONFIG_DIR=/home/agent/.claude` — set inside the container regardless of whether the host had `CLAUDE_CONFIG_DIR`; points to the mount point.
 - `--output-format stream-json` — instructs claude to emit newline-delimited JSON (NDJSON) on stdout. Required for the `claudestream` pipeline to parse typed events.
@@ -143,6 +143,13 @@ type SandboxOptions struct {
     // CidfilePath is the --cidfile path to clean up after the step exits.
     // May be empty. Cleanup is ENOENT-tolerant.
     CidfilePath string
+    // ArtifactPath is the path for the per-step .jsonl file (D14). When
+    // non-empty and CaptureMode == CaptureResult, a RawWriter is opened here.
+    ArtifactPath string
+    // CaptureMode selects the capture semantics for the step. CaptureResult
+    // activates the claudestream pipeline. Zero value (CaptureLastLine)
+    // preserves current non-pipeline behaviour.
+    CaptureMode ui.CaptureMode
 }
 ```
 
@@ -171,7 +178,7 @@ Runner.Terminate()
         └── docker kill --signal=KILL <container-id>
 ```
 
-The terminator is constructed by `sandbox.NewTerminator(cmd, cidfilePath)`. It polls the cidfile for up to 500ms at 50ms intervals (the file is written by the Docker daemon shortly after the container starts). If the cidfile never appears, it falls back to signaling the host `docker run` CLI process directly.
+The terminator is constructed by `sandbox.NewTerminator(cmd, cidfilePath)`. It polls the cidfile for up to 2 seconds at 50ms intervals (the file is written by the Docker daemon shortly after the container starts). If the cidfile never appears, it falls back to signaling the host `docker run` CLI process directly.
 
 `currentTerminator` is cleared before `procDone` is closed, preventing stale signal dispatch if `Terminate()` races with natural step completion.
 
@@ -206,6 +213,7 @@ The following residual risks are accepted:
 - [Subprocess Execution & Streaming](subprocess-execution.md) — `RunSandboxedStep`, `SandboxOptions`, terminator lifecycle, cidfile cleanup
 - [Config Validation](config-validation.md) — Sandbox rules B and C (prompt-token ban, captureAs+tokens-in-command; Rule A removed in issue #91)
 - [Step Definitions & Prompt Building](step-definitions.md) — `StepFile.Env` field and `BuildRunArgs` call site in `buildStep`
+- [Passing Environment Variables](../how-to/passing-environment-variables.md) — User-facing guide for declaring env vars in `ralph-steps.json`
 - [Variable Output & Injection](../how-to/variable-output-and-injection.md) — Why `{{WORKFLOW_DIR}}` and `{{PROJECT_DIR}}` are banned in prompt files
 - [ADR: Require Docker Sandbox](../adr/20260413160000-require-docker-sandbox.md) — Decision to make Docker a runtime requirement
 - [ADR: workflow-dir / project-dir split](../adr/20260413162428-workflow-project-dir-split.md) — Why `PROJECT_DIR` means the target repo (not the workflow bundle)

--- a/docs/features/file-logging.md
+++ b/docs/features/file-logging.md
@@ -120,9 +120,9 @@ func (l *Logger) Log(stepName string, line string) error {
 }
 ```
 
-### RunStamp
+### RunStamp and Per-Run Artifact Directory
 
-`RunStamp()` returns the run identifier — the log filename without the `.log` suffix (e.g. `"ralph-2026-04-14-173022.123"`). It is set once at construction and never changes. `main.go` reads this after `NewLogger` and passes it into `RunConfig.RunStamp` so that `claudestream.Pipeline` can construct the per-run artifact directory (`projectDir/logs/<runstamp>/`):
+`RunStamp()` returns the run identifier — the log filename without the `.log` suffix (e.g. `"ralph-2026-04-14-173022.123"`). It is set once at construction and never changes. `main.go` reads this after `NewLogger` and eagerly creates the per-run artifact directory `logs/<runstamp>/` via `os.MkdirAll` before any workflow steps run. The `RunStamp` is then passed into `RunConfig.RunStamp` so that `claudestream.Pipeline` can write per-step `.jsonl` files into the artifact directory:
 
 ```go
 func (l *Logger) RunStamp() string {

--- a/docs/features/keyboard-input.md
+++ b/docs/features/keyboard-input.md
@@ -1,6 +1,6 @@
 # Keyboard Input & Error Recovery
 
-A four-mode state machine that routes keypresses and communicates user decisions to the orchestration goroutine via a channel.
+A six-mode state machine that routes keypresses and communicates user decisions to the orchestration goroutine via a channel.
 
 - **Last Updated:** 2026-04-11
 - **Authors:**
@@ -8,14 +8,15 @@ A four-mode state machine that routes keypresses and communicates user decisions
 
 ## Overview
 
-- `KeyHandler` operates in four modes: Normal, Error, QuitConfirm, and Quitting — each with its own keypress bindings and shortcut bar text
+- `KeyHandler` operates in six modes: Normal, Error, QuitConfirm, NextConfirm, Done, and Quitting — each with its own keypress bindings and shortcut bar text
 - User decisions are sent to the orchestration goroutine via a buffered `Actions` channel carrying `StepAction` values (Retry, Continue, Quit)
-- In Normal mode, `n` terminates the current subprocess (skip step) and `q` enters quit confirmation
+- In Normal mode, `n` enters the skip confirmation prompt (NextConfirm) and `q` enters quit confirmation
+- In NextConfirm mode (entered when the user presses `n` during a running step), `y` terminates the current subprocess (skip step), `n` or `<Escape>` cancel and restore the previous mode
 - In Error mode (entered when a step fails), `c` continues past the failure, `r` retries the step, and `q` enters quit confirmation
-- In QuitConfirm mode, `y` flips to the `Quitting` mode (footer shows `Quitting...`) and calls `ForceQuit`; `n` or `<Escape>` cancel and restore the previous mode
+- In QuitConfirm mode, `y` flips to the `Quitting` mode (footer shows `Quitting...`), calls `ForceQuit`, and returns `tea.QuitMsg` to exit the TUI; `n` or `<Escape>` cancel and restore the previous mode
+- In Done mode (entered when the workflow completes), the TUI stays alive so the user can review output; `q` enters quit confirmation
 - In Quitting mode the footer shows `Quitting...` as visible confirmation that the user's quit was accepted while the orchestration goroutine unwinds
 - `ForceQuit()` is a signal-safe method that terminates the subprocess and injects `ActionQuit` via non-blocking send — it is called both by the OS signal handler (SIGINT/SIGTERM) and by the QuitConfirm `y` path, so both paths produce identical shutdown behavior
-- When the workflow finishes normally, `Run` returns on its own (no "press any key to exit" state); the workflow goroutine in `main.go` restores the terminal and exits the process directly
 
 Key files:
 - `ralph-tui/internal/ui/ui.go` — KeyHandler struct, mode state, ForceQuit, ShortcutLine
@@ -39,41 +40,41 @@ Key files:
       ┌────────────┐           ┌────────────┐
       │ ModeNormal │           │ ModeError  │
       │            │           │            │
-      │ n → cancel │           │ c → cont.  │
-      │   (skip)   │           │ r → retry  │
-      │ q ───┐     │           │ q ───┐     │
-      └──────┼─────┘           └──────┼─────┘
-             │                        │
-             └──────────┬─────────────┘
-                        ▼
-            ┌───────────────────────┐
-            │   ModeQuitConfirm     │
-            │                       │
-            │  y → ModeQuitting +   │
-            │      ForceQuit        │
-            │  n, <Escape> → prev   │
-            └───────────┬───────────┘
-                        │
-                        │ y
-                        ▼
-                 ┌──────────────┐
-                 │ ModeQuitting │
-                 │              │
-                 │ footer shows │
-                 │ "Quitting..."│
-                 │ (terminal)   │
-                 └──────┬───────┘
-                        │
-                        │ ForceQuit →
-                        ▼
-                 ┌──────────────┐
-                 │   Actions    │  buffered channel (cap 10)
-                 │   channel    │
-                 └──────┬───────┘
-                        │
-                        ▼
-                 Orchestrate()
-                 (workflow goroutine)
+      │ n ───┐     │           │ c → cont.  │
+      │ q ───┼─┐   │           │ r → retry  │
+      └──────┼─┼───┘           │ q ───┐     │
+             │ │               └──────┼─────┘
+             │ └──────────┬───────────┘
+             │            ▼
+             │  ┌───────────────────────┐
+             │  │   ModeQuitConfirm     │
+             │  │                       │
+             │  │  y → ModeQuitting +   │
+             │  │      ForceQuit +      │
+             │  │      tea.QuitMsg      │
+             │  │  n, <Escape> → prev   │
+             │  └───────────┬───────────┘
+             │              │
+             ▼              │ y
+    ┌──────────────────┐    ▼
+    │ ModeNextConfirm  │  ┌──────────────┐
+    │                  │  │ ModeQuitting │
+    │ "Skip current    │  │              │
+    │  step? (y/n,     │  │ footer shows │
+    │  esc to cancel)" │  │ "Quitting..."│
+    │                  │  │ (terminal)   │
+    │ y → cancel step  │  └──────┬───────┘
+    │ n, esc → prev    │         │
+    └──────────────────┘         │ ForceQuit →
+                                 ▼
+                          ┌──────────────┐
+                          │   Actions    │  buffered channel (cap 10)
+                          │   channel    │
+                          └──────┬───────┘
+                                 │
+                                 ▼
+                          Orchestrate()
+                          (workflow goroutine)
 
   OS Signal (SIGINT/SIGTERM):
     → signal handler goroutine
@@ -82,10 +83,18 @@ Key files:
     (unified with the QuitConfirm 'y' path)
 
   Normal completion:
-    → Run returns on its own after writing the
-      completion summary to the log body
-    → workflow goroutine restores the terminal
-      and os.Exit(0)s directly
+    → workflow goroutine enters ModeDone
+    → TUI stays alive; user reviews output
+    → q → QuitConfirm → y → tea.QuitMsg exits TUI
+
+                 ┌──────────────┐
+                 │   ModeDone   │
+                 │              │
+                 │ footer shows │
+                 │ "q quit"    │
+                 │              │
+                 │ q → QuitConfirm │
+                 └──────────────┘
 ```
 
 ## Key Files
@@ -112,6 +121,8 @@ const (
     ModeNormal      Mode = iota
     ModeError
     ModeQuitConfirm
+    ModeNextConfirm // entered after n; shows "Skip current step?" prompt
+    ModeDone        // entered after workflow completes; shows "q quit" footer
     ModeQuitting    // confirmed quit; footer shows "Quitting..." during shutdown
 )
 
@@ -133,6 +144,8 @@ type KeyHandler struct {
 | `NormalShortcuts` | `"↑/k up  ↓/j down  n next step  q quit"` | Shortcut bar in normal mode |
 | `ErrorShortcuts` | `"c continue  r retry  q quit"` | Shortcut bar in error mode |
 | `QuitConfirmPrompt` | `"Quit " + AppTitle + "? (y/n, esc to cancel)"` | Shortcut bar in quit confirm mode |
+| `NextConfirmPrompt` | `"Skip current step? (y/n, esc to cancel)"` | Shortcut bar in next-confirm mode |
+| `DoneShortcuts` | `"q quit"` | Shortcut bar in done mode (post-workflow) |
 | `QuittingLine` | `"Quitting..."` | Shortcut bar in quitting mode (visible while shutdown unwinds) |
 
 ## Implementation Details
@@ -151,6 +164,8 @@ func (m keysModel) Update(msg tea.Msg) (keysModel, tea.Cmd) {
     case ModeNormal:      return m.handleNormal(key)
     case ModeError:       return m.handleError(key)
     case ModeQuitConfirm: return m.handleQuitConfirm(key)
+    case ModeNextConfirm: return m.handleNextConfirm(key)
+    case ModeDone:        return m.handleDone(key)
     case ModeQuitting:
         // All keys silently ignored so a user mashing keys during shutdown
         // can't inject a second ActionQuit or retrigger the cancel hook.
@@ -166,8 +181,17 @@ The Bubble Tea program delivers all keypresses as `tea.KeyMsg` to `Model.Update`
 
 ### Normal Mode
 
-- `n` — calls the `cancel` function to terminate the current subprocess (step skip)
+- `n` — if a cancel function is available (subprocess running), saves the current mode as `prevMode` and switches to `ModeNextConfirm`; if no cancel function (no subprocess), no-op
 - `q` — saves the current mode as `prevMode` and switches to `ModeQuitConfirm` (direct field write under `handler.mu`)
+- All other keys are ignored
+
+### NextConfirm Mode
+
+Entered when the user presses `n` during a running step. The footer shows `NextConfirmPrompt` (`"Skip current step? (y/n, esc to cancel)"`):
+
+- `y` — re-acquires the cancel function, restores `prevMode`, and offloads `cancel()` via `tea.Cmd` (same goroutine-offload pattern as the old direct-cancel path). Re-acquiring cancel is safe because the subprocess is still running while in `ModeNextConfirm`
+- `n` — restores `prevMode` (cancels the skip without terminating the subprocess)
+- `<Escape>` — same as `n`
 - All other keys are ignored
 
 ### Error Mode
@@ -180,20 +204,25 @@ Entered by `Orchestrate` when a step fails (via `h.SetMode(ModeError)`):
 
 ### Quit Confirm Mode
 
-- `y` — flips the mode to `ModeQuitting` (so the footer immediately shows `Quitting...` as visible feedback) and calls `ForceQuit()`, which terminates the active subprocess and injects `ActionQuit` into the Actions channel
+- `y` — calls `ForceQuit()` (which sets `ModeQuitting` and terminates the subprocess) and returns `tea.QuitMsg{}` so the TUI exits. Returning `tea.QuitMsg` is needed because in `ModeDone` there is no workflow goroutine to call `program.Quit()` — the QuitMsg causes `program.Run()` to return directly
 - `n` — restores `prevMode` (returns to whichever mode initiated the quit)
 - `<Escape>` — same as `n`: restores `prevMode` and cancels the quit without firing `ForceQuit` or sending any action
 - All other keys are ignored
 
-The flip to `ModeQuitting` happens **before** `ForceQuit` is called so the footer paints `Quitting...` on the very next render cycle, before the orchestration goroutine starts unwinding. This is the only mode that exists purely for user feedback — no keypresses are processed from `ModeQuitting` because the state machine will either terminate the process (signal path) or the workflow goroutine will close the executor and return from `Run` (normal path).
+`ForceQuit` sets `ModeQuitting` internally so the footer paints `Quitting...` on the very next render cycle, before the orchestration goroutine starts unwinding.
 
 ### Quitting Mode
 
 Entered by the QuitConfirm `y` path or by `ForceQuit()` directly (which is called by the OS signal handler from any mode, including Normal and Error). The footer shows `QuittingLine` (`"Quitting..."`). No keypress handler is registered for this mode; any keypresses received while `mode == ModeQuitting` fall through `Handle`'s switch and are ignored. The mode persists until the workflow goroutine unwinds and tears the TUI down.
 
-### Normal Completion (no mode transition)
+### Done Mode
 
-When the workflow finishes all iterations and finalize steps successfully, `Run` writes the completion summary line to the log body and returns on its own. There is no dedicated "done" mode — the workflow goroutine in `main.go` calls `program.Quit()` after `workflow.Run` returns, which causes `program.Run()` to return cleanly in `main`.
+When the workflow finishes all iterations and finalize steps successfully, `Run` writes the completion summary line to the log body and returns. The workflow goroutine in `main.go` flushes logs, closes channels, and calls `keyHandler.SetMode(ModeDone)`. The TUI stays alive so the user can scroll through the output. The footer shows `DoneShortcuts` (`"q quit"`):
+
+- `q` — saves `ModeDone` as `prevMode` and enters `ModeQuitConfirm`
+- All other keys are ignored
+
+From `ModeQuitConfirm`, `y` triggers `ForceQuit` + `tea.QuitMsg` which causes `program.Run()` to return. `<Escape>` or `n` restores `ModeDone`.
 
 ### ForceQuit
 
@@ -258,7 +287,7 @@ This means scroll keys (`↑`/`k`/`↓`/`j`) work during Normal mode — the vie
 
 ## Testing
 
-- `ralph-tui/internal/ui/ui_test.go` — Tests for all key handlers in each mode, mode transitions, quit confirm with cancel (`n` and `<Escape>` from both Normal and Error), `y` flipping to `ModeQuitting` with `QuittingLine` footer, `SetMode(ModeQuitting)` updating the shortcut bar, ForceQuit (cancel fires, ActionQuit sent, idempotent, nil-cancel-no-panic, full-channel-no-panic, `TestForceQuit_SetsModeQuitting_FromNormal`, `TestForceQuit_SetsModeQuitting_FromError`), ShortcutLine thread safety
+- `ralph-tui/internal/ui/ui_test.go` — Tests for all key handlers in each mode, mode transitions, quit confirm with cancel (`n` and `<Escape>` from Normal, Error, and Done), `y` flipping to `ModeQuitting` with `QuittingLine` footer and returning `tea.QuitMsg`, `SetMode` for all six modes, ForceQuit (cancel fires, ActionQuit sent, idempotent, nil-cancel-no-panic, full-channel-no-panic, `TestForceQuit_SetsModeQuitting_FromNormal`, `TestForceQuit_SetsModeQuitting_FromError`, `TestForceQuit_SetsModeQuitting_FromNextConfirm`, `TestForceQuit_SetsModeQuitting_FromDone`), ShortcutLine thread safety with all six modes
 
 ## Additional Information
 

--- a/docs/features/preflight.md
+++ b/docs/features/preflight.md
@@ -38,8 +38,10 @@ Stats `path`:
 func CheckCredentials(profileDir string) (warning string, _ error)
 ```
 
-Checks `<profileDir>/.credentials.json`:
-- Missing file → empty warning, nil error (fresh profile is valid)
+When `ANTHROPIC_API_KEY` is set on the host, the credentials file check is skipped entirely — the sandbox authenticates via the `BuiltinEnvAllowlist` passthrough and the file is not required. Returns `("", nil)` immediately.
+
+Otherwise, checks `<profileDir>/.credentials.json`:
+- Missing file → non-empty warning with guidance to run `ralph-tui sandbox login` or set `ANTHROPIC_API_KEY`, nil error
 - Zero-byte file → non-empty warning containing "will likely fail authentication"
 - Non-empty file → empty warning, nil error
 - Any stat error other than `os.ErrNotExist` → propagated as an error (not a warning)

--- a/docs/features/signal-handling.md
+++ b/docs/features/signal-handling.md
@@ -31,16 +31,12 @@ Key files:
        ▼
   signal handler goroutine:
   ┌──────────────────────────────────────────────┐
-  │  select {                                    │
-  │  case <-sigChan:                             │
-  │    close(signaled)       ← one-shot flag     │
-  │    keyHandler.ForceQuit()  ← terminate sub + │
-  │                               inject ActionQuit│
-  │    wait on <-workflowDone or 2s timeout      │
-  │    program.Kill()        ← forced TUI stop   │
-  │  case <-workflowDone:                        │
-  │    return                ← workflow finished  │
-  │  }                                           │
+  │  <-sigChan               ← blocks unconditionally│
+  │  close(signaled)         ← one-shot flag     │
+  │  keyHandler.ForceQuit()  ← terminate sub +   │
+  │                             inject ActionQuit│
+  │  wait on <-workflowDone or 2s timeout        │
+  │  program.Kill()          ← always kill       │
   └──────────────────────────────────────────────┘
        │
        ├───▶ Runner.Terminate()     → SIGTERM subprocess, SIGKILL after 3s
@@ -57,14 +53,16 @@ Key files:
   ┌──────────────────────────┐
   │  defer close(workflowDone)│
   │  workflow.Run(...)       │
-  │  signal.Stop(sigChan)    │  ← deregister signal handler
   │  log.Close()             │  ← flush and close log file
   │  close(lineCh)           │  ← signal drain goroutine to exit
-  │  program.Quit()          │  ← stop the Bubble Tea TUI
+  │  keyHandler.SetMode(     │
+  │    ui.ModeDone)          │  ← TUI stays alive for user review
   └──────────────────────────┘
 
   main goroutine (after program.Run() returns):
   ┌─────────────────────────────────────────┐
+  │  signal.Stop(sigChan)                   │  ← deregister after TUI exits
+  │  wait on <-workflowDone or 4s timeout   │  ← flush logs, close channels
   │  select {                               │
   │  case <-signaled:                       │
   │    os.Exit(1)   ← signal-initiated      │
@@ -86,22 +84,20 @@ sigChan := make(chan os.Signal, 1)
 signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 signaled := make(chan struct{})
 go func() {
+    <-sigChan
+    close(signaled)
+    keyHandler.ForceQuit()
     select {
-    case <-sigChan:
-        close(signaled)
-        keyHandler.ForceQuit()
-        // Give the workflow goroutine up to 2 seconds to exit cleanly.
-        select {
-        case <-workflowDone:
-        case <-time.After(2 * time.Second):
-            program.Kill()
-        }
     case <-workflowDone:
+    case <-time.After(2 * time.Second):
     }
+    program.Kill()
 }()
 ```
 
-The `signaled` channel is a one-shot flag — once closed, it stays closed. The signal handler calls `keyHandler.ForceQuit()` to terminate the subprocess and inject `ActionQuit`, then waits up to 2 seconds for the workflow goroutine to unwind cleanly. If it doesn't, `program.Kill()` forces the Bubble Tea program to stop (returning `tea.ErrProgramKilled` from `program.Run()`). Exit code selection happens in the main goroutine after `program.Run()` returns, not inside the signal handler.
+The signal handler blocks unconditionally on `<-sigChan` — there is no `case <-workflowDone` escape hatch. This ensures the handler remains active during `ModeDone` (post-workflow), so a SIGINT on the done screen still triggers `ForceQuit` + `program.Kill()` and restores the terminal cleanly. If no signal ever arrives, the goroutine stays blocked forever — this is fine because the process exits when `program.Run()` returns (via `q` → `y` → `tea.QuitMsg`), and the goroutine is cleaned up by process exit.
+
+After `ForceQuit`, the handler waits up to 2 seconds for the workflow goroutine to finish, then always calls `program.Kill()`. If the signal arrives during `ModeDone` (workflow already finished), `<-workflowDone` resolves immediately and `program.Kill()` force-stops the TUI.
 
 ### ForceQuit Integration
 
@@ -134,26 +130,34 @@ This catches the `ActionQuit` injected by `ForceQuit` even if the signal arrives
 
 ### Workflow Goroutine Cleanup
 
-On normal workflow completion, `signal.Stop`, `log.Close`, `close(lineCh)`, and `program.Quit()` all run inside the workflow goroutine before `workflowDone` is closed:
+On normal workflow completion, the workflow goroutine flushes logs, closes channels, and enters `ModeDone` — the TUI stays alive so the user can review output:
 
 ```go
 go func() {
     defer close(workflowDone)
     _ = workflow.Run(runner, proxy, keyHandler, runCfg)
-    signal.Stop(sigChan)  // deregister signal handler
-    _ = log.Close()       // flush and close the log file
-    close(lineCh)         // signal drain goroutine to exit
-    program.Quit()        // stop the Bubble Tea TUI
+    _ = log.Close()                    // flush and close the log file
+    close(lineCh)                      // signal drain goroutine to exit
+    keyHandler.SetMode(ui.ModeDone)    // TUI stays alive for user review
 }()
 ```
 
-Placing cleanup here ensures it always runs when the workflow finishes naturally, without relying on the main goroutine to sequence it.
+`signal.Stop(sigChan)` is no longer called here — signals stay registered until the process exits, so the signal handler goroutine remains active during `ModeDone`. The user exits via `q` → `y` → `tea.QuitMsg`, which causes `program.Run()` to return. `signal.Stop` is called after `program.Run()` returns in the main goroutine.
 
 ### Exit Code Selection
 
-After `program.Run()` returns, the main goroutine checks whether a signal was received:
+After `program.Run()` returns, the main goroutine deregisters signals, waits for the workflow goroutine to finish cleanup, then selects the exit code:
 
 ```go
+_, runErr := program.Run()
+signal.Stop(sigChan)
+
+// Wait for the workflow goroutine to finish cleanup (log flush, channel close).
+select {
+case <-workflowDone:
+case <-time.After(4 * time.Second):
+}
+
 select {
 case <-signaled:
     os.Exit(1)  // signal-initiated shutdown
@@ -162,7 +166,9 @@ default:
 }
 ```
 
-`program.Run()` returns when `program.Quit()` (normal path) or `program.Kill()` (signal path) is called. Before exit code selection, any non-nil error from `program.Run()` is inspected:
+`signal.Stop(sigChan)` deregisters signal notifications after the TUI exits cleanly. The `workflowDone` wait ensures the workflow goroutine's cleanup completes before `os.Exit`. The 4-second timeout exceeds the 3-second `terminateGracePeriod` in `runner.Terminate()` plus buffer for `log.Close()` and `close(lineCh)`.
+
+`program.Run()` returns when `tea.QuitMsg` is received (user quit via `q` → `y`) or `program.Kill()` is called (signal path). Before exit code selection, any non-nil error from `program.Run()` is inspected:
 
 ```go
 if runErr != nil && !errors.Is(runErr, tea.ErrProgramKilled) {

--- a/docs/features/subprocess-execution.md
+++ b/docs/features/subprocess-execution.md
@@ -106,7 +106,16 @@ type Runner struct {
     // that used the claudestream pipeline. Reset on each RunSandboxedStep entry.
     // Protected by mu; read by LastStats.
     lastStats claudestream.StepStats
+
+    // activePipeline and activePipelineStartedAt support the heartbeat indicator.
+    // Set when a claude step starts; cleared in a LIFO defer before pipeline.Close().
+    // Protected by processMu; read by HeartbeatSilence.
+    activePipeline          *claudestream.Pipeline
+    activePipelineStartedAt time.Time
 }
+
+// Compile-time assertion that *Runner satisfies ui.HeartbeatReader.
+var _ ui.HeartbeatReader = (*Runner)(nil)
 
 // SandboxOptions carries the sandbox-specific parameters for RunSandboxedStep.
 type SandboxOptions struct {

--- a/docs/features/tui-display.md
+++ b/docs/features/tui-display.md
@@ -282,7 +282,7 @@ There is **no** `lipgloss.Border` wrapper around the inner block. The previous a
 
 `colorShortcutLine()` applies the footer's per-key color scheme. For the key-mapping lines (`NormalShortcuts`, `ErrorShortcuts`), the string is split on `"  "` (double-space) into groups; within each group the first whitespace-separated token is the mapped key (rendered `White`) and the rest is its description (rendered `LightGray`). The `"  "` separators between groups remain `LightGray`.
 
-For status-message lines the whole string renders in `White`, with one exception: when the line is `QuitConfirmPrompt`, `colorShortcutLine` splits the string on the `AppTitle` substring and renders that substring in `Green` to match the top-border title's brand color, with the surrounding prompt text in `White`.
+For status-message lines (`QuitConfirmPrompt`, `NextConfirmPrompt`, `QuittingLine`) the whole string renders in `White`, with one exception: when the line is `QuitConfirmPrompt`, `colorShortcutLine` splits the string on the `AppTitle` substring and renders that substring in `Green` to match the top-border title's brand color, with the surrounding prompt text in `White`. `DoneShortcuts` (`"q quit"`) uses the default two-tone rendering (key white, description gray) since it follows the standard key-mapping format.
 
 ### Checkbox Label Formatting
 

--- a/docs/features/tui-display.md
+++ b/docs/features/tui-display.md
@@ -60,7 +60,7 @@ Key files:
   │  │ [log panel — bubbles/viewport]            │ ││  ← scrollable log viewport (white text)
   │  │├───────────────────────────────────────── ┤ ││  ← HRule (T-junctions)
   │  │ ↑/k up  ↓/j down  n next  q quit          │ ││  ← shortcut footer (ShortcutLine)
-  │  │                     ralph-tui v0.2.1      │ ││  ← version label (right-aligned, white)
+  │  │                     ralph-tui v0.4.1      │ ││  ← version label (right-aligned, white)
   │  │╰─────────────────────────────────────────╯  ││  ← bottom border
   │  └──────────────────────────────────────────────┘│
   └──────────────────────────────────────────────────┘
@@ -242,7 +242,7 @@ go func() {
     ticker := time.NewTicker(time.Second)
     defer ticker.Stop()
     for range ticker.C {
-        program.Send(ui.HeartbeatTickMsg(time.Now()))
+        program.Send(ui.HeartbeatTickMsg{})
     }
 }()
 

--- a/docs/how-to/building-custom-workflows.md
+++ b/docs/how-to/building-custom-workflows.md
@@ -143,6 +143,7 @@ User-initiated skips (pressing **n** during a step) are not treated as failures 
 - [Getting Started](getting-started.md) — Install, first run, and orientation
 - [Variable Output & Injection](variable-output-and-injection.md) — How `{{VAR}}` tokens are resolved into prompts and commands
 - [Capturing Step Output](capturing-step-output.md) — How to use `captureAs` to bind step stdout to a variable
+- [Passing Environment Variables](passing-environment-variables.md) — How to forward host env vars into the Docker sandbox via the `env` field
 - [Breaking Out of the Loop](breaking-out-of-the-loop.md) — Using `breakLoopIfEmpty` to exit the iteration loop dynamically
 - [Recovering from Step Failures](recovering-from-step-failures.md) — Error mode keyboard controls and decision-making
 - [Debugging a Run](debugging-a-run.md) — Reading logs and reproducing failures

--- a/docs/how-to/getting-started.md
+++ b/docs/how-to/getting-started.md
@@ -58,7 +58,7 @@ To check which version you are running without launching the workflow:
 
 ```bash
 /path/to/pr9k/bin/ralph-tui --version
-# ralph-tui version 0.2.1
+# ralph-tui version 0.4.1
 ```
 
 `-v` is accepted as a short alias. See [Versioning](../coding-standards/versioning.md) for the repo's semver rules.
@@ -107,13 +107,16 @@ For a detailed walk-through of the TUI layout and what each region means, see [R
 
 | Mode | Keys | Effect |
 |------|------|--------|
-| Normal | `n` | Terminate the current subprocess (skip the step) |
+| Normal | `n` | Enter skip-confirm (`Skip current step? y/n, esc to cancel`) |
 | Normal | `q` | Enter quit-confirm |
+| NextConfirm | `y` | Confirm skip — terminate the current subprocess |
+| NextConfirm | `n` or `Esc` | Cancel skip, return to normal mode |
 | Error (step failed) | `c` | Accept the failure, advance to next step |
 | Error (step failed) | `r` | Re-run the failed step |
 | Error (step failed) | `q` | Enter quit-confirm |
 | QuitConfirm | `y` | Confirm quit (footer flips to `Quitting...`) |
 | QuitConfirm | `n` or `Esc` | Cancel quit, return to previous mode |
+| Done (workflow complete) | `q` | Enter quit-confirm to exit |
 
 See [Recovering from Step Failures](recovering-from-step-failures.md) and [Quitting Gracefully](quitting-gracefully.md) for the full interaction model.
 
@@ -123,6 +126,7 @@ See [Recovering from Step Failures](recovering-from-step-failures.md) and [Quitt
 - **Adapting the workflow for your project:** [Building Custom Workflows](building-custom-workflows.md)
 - **Learning the variable substitution engine:** [Variable Output & Injection](variable-output-and-injection.md)
 - **Capturing a step's output for later steps:** [Capturing Step Output](capturing-step-output.md)
+- **Forwarding host env vars to the sandbox:** [Passing Environment Variables](passing-environment-variables.md)
 - **Stopping the iteration loop dynamically:** [Breaking Out of the Loop](breaking-out-of-the-loop.md)
 - **Reading the run's log file:** [Debugging a Run](debugging-a-run.md)
 - **Understanding the architecture:** [Architecture Overview](../architecture.md)

--- a/docs/how-to/passing-environment-variables.md
+++ b/docs/how-to/passing-environment-variables.md
@@ -1,0 +1,99 @@
+# Passing Environment Variables to the Sandbox
+
+Claude steps run inside a Docker container with a scrubbed environment. By default, only five sandbox-plumbing variables are forwarded from the host. If your workflow needs additional host environment variables inside the container — API tokens, proxy settings, feature flags — you declare them in `ralph-steps.json`.
+
+## The `env` field
+
+Add a top-level `env` array to your `ralph-steps.json`:
+
+```json
+{
+  "env": ["GH_TOKEN", "MY_CUSTOM_VAR"],
+  "initialize": [ ... ],
+  "iteration": [ ... ],
+  "finalize": [ ... ]
+}
+```
+
+Each entry is the **name** of a host environment variable (not a `KEY=VALUE` pair). Docker reads the value from the host environment at container start. If the variable is not set on the host, it is silently skipped — no error, no empty string injected.
+
+The `env` array applies to **all** `isClaude: true` steps. Shell command steps run directly on the host and inherit the full host environment, so they do not need `env` entries.
+
+## What gets forwarded automatically
+
+Five variables are always attempted, regardless of the `env` field:
+
+| Variable | Purpose |
+|----------|---------|
+| `ANTHROPIC_API_KEY` | Direct API authentication (bypasses OAuth) |
+| `ANTHROPIC_BASE_URL` | Custom API endpoint |
+| `HTTPS_PROXY` | HTTPS proxy for outbound requests |
+| `HTTP_PROXY` | HTTP proxy for outbound requests |
+| `NO_PROXY` | Proxy exclusion list |
+
+These are defined in `sandbox.BuiltinEnvAllowlist`. You do not need to repeat them in `env`.
+
+Additionally, `CLAUDE_CONFIG_DIR=/home/agent/.claude` is always set inside the container with an explicit value (the mount point), not a passthrough.
+
+## How merging works
+
+At build time, ralph-tui merges the builtin allowlist with your `env` entries:
+
+```
+final allowlist = BuiltinEnvAllowlist + env (from ralph-steps.json)
+```
+
+Duplicates are de-duplicated by name (first-seen wins). Each name is passed to Docker as `-e NAME` (no `=VALUE`), so Docker reads the value from the host. If `os.LookupEnv(name)` returns false on the host, the `-e` flag is still added — Docker itself silently omits unset variables.
+
+## Validation rules
+
+The D13 config validator (Category 10) checks every entry in `env` at startup. A validation error exits 1 before the TUI starts:
+
+| Rule | Example violation |
+|------|-------------------|
+| Empty string | `""` |
+| Invalid identifier | `"MY-VAR"` (hyphens not allowed), `"123ABC"` (starts with digit) |
+| Reserved sandbox name | `"CLAUDE_CONFIG_DIR"`, `"HOME"` |
+| Denied for safety | `"PATH"`, `"USER"`, `"SSH_AUTH_SOCK"`, `"LD_PRELOAD"` |
+
+Valid names match the regex `^[A-Za-z_][A-Za-z0-9_]*$`.
+
+## Example: forwarding a GitHub token
+
+The default workflow forwards `GH_TOKEN` so that Claude can use the GitHub CLI inside the container:
+
+```json
+{
+  "env": ["GH_TOKEN"],
+  "initialize": [ ... ],
+  "iteration": [ ... ],
+  "finalize": [ ... ]
+}
+```
+
+Before running ralph-tui, set the variable on the host:
+
+```bash
+export GH_TOKEN=$(gh auth token)
+/path/to/bin/ralph-tui
+```
+
+Inside the container, `echo $GH_TOKEN` will print the token value.
+
+## Debugging: is my variable reaching the container?
+
+If a claude step fails because it can't find an expected variable:
+
+1. Verify the variable is set on the host: `echo $MY_VAR`
+2. Verify it's listed in `ralph-steps.json`'s `env` array
+3. Check that the validator didn't reject it: validation errors appear on stderr before the TUI starts
+4. Check for typos — the name must match exactly (case-sensitive)
+
+## Related documentation
+
+- [Docker Sandbox](../features/docker-sandbox.md) — Mount layout, env allowlist behavior, and the full `docker run` command
+- [sandbox Package](../features/sandbox.md) — `BuildRunArgs`, `BuiltinEnvAllowlist`, and set-on-host filtering
+- [Config Validation](../features/config-validation.md) — Category 10 env validation rules
+- [Building Custom Workflows](building-custom-workflows.md) — How to create custom step sequences
+- [Step Definitions & Prompt Building](../features/step-definitions.md) — The `StepFile.Env` field in the JSON schema
+- [Setting Up Docker Sandbox](setting-up-docker-sandbox.md) — First-time Docker setup and authentication

--- a/docs/how-to/quitting-gracefully.md
+++ b/docs/how-to/quitting-gracefully.md
@@ -8,7 +8,7 @@ Ralph-tui always shuts down through the same path — whether you press `q`, hit
 |-------------|----------------|--------------|
 | `q` in Normal or Error mode, then `y` | `KeyHandler.handleQuitConfirm` | Flips footer to `Quitting...` (white), calls `ForceQuit` |
 | `Ctrl+C` (SIGINT) or `kill` (SIGTERM) | Signal handler goroutine in `main.go` | Calls `ForceQuit`, waits up to 2s, then `program.Kill()` |
-| Workflow completes normally | The workflow goroutine in `main.go` | `Run` returns on its own; calls `program.Quit()` |
+| Workflow completes normally | The workflow goroutine in `main.go` | `Run` returns on its own; enters `ModeDone` (`q quit` footer) |
 
 The two interactive paths go through `KeyHandler.ForceQuit()` to unify subprocess termination and `ActionQuit` injection — you get the same shutdown semantics whether you press `y` or hit Ctrl+C. The normal-completion path doesn't need `ForceQuit` because there's nothing to cancel.
 
@@ -65,11 +65,11 @@ The OS signal handler in `main.go` listens for SIGINT and SIGTERM on a buffered 
 
 Because the signal handler calls `ForceQuit`, **the signal path and the `q`→`y` path produce identical behavior from the workflow's perspective.** The only difference is the exit code: SIGINT/SIGTERM exits 1, a normal `q`→`y` shutdown exits 0.
 
-The signal handler also runs whether or not the TUI is currently in Normal, Error, QuitConfirm, or Quitting mode — signals bypass the mode dispatcher entirely.
+The signal handler also runs whether or not the TUI is currently in Normal, Error, QuitConfirm, NextConfirm, Done, or Quitting mode — signals bypass the mode dispatcher entirely.
 
 ## The normal-completion path
 
-When `Run` finishes all iterations and finalize steps, it writes the completion summary to the log body and returns on its own — no keypress required. The workflow goroutine in `main.go` then calls `signal.Stop`, flushes the log, closes the drain channel, and calls `program.Quit()`. This causes `program.Run()` to return cleanly in main, which then selects the exit code and calls `os.Exit(0)`.
+When `Run` finishes all iterations and finalize steps, it writes the completion summary to the log body and returns. The workflow goroutine in `main.go` then flushes the log, closes the drain channel, and calls `keyHandler.SetMode(ui.ModeDone)`. The TUI stays alive with a `q quit` footer so you can review the final output. Press `q` then `y` to exit — this sends `tea.QuitMsg`, which causes `program.Run()` to return. After `program.Run()` returns, `main` calls `signal.Stop`, waits for the workflow goroutine to finish cleanup, selects the exit code, and calls `os.Exit(0)`.
 
 ## Exit codes
 
@@ -99,7 +99,7 @@ The window is usually a fraction of a second — just long enough for the subpro
 
 Some interactions look like they might quit but don't:
 
-- **`n` in Normal mode** — `n` means "skip the current step", not "quit". It sends SIGTERM to the subprocess and advances to the next step. See [Recovering from Step Failures](recovering-from-step-failures.md) for how skips interact with the workflow.
+- **`n` in Normal mode** — `n` means "skip the current step", not "quit". It enters a `ModeNextConfirm` prompt (`Skip current step? y/n, esc to cancel`). Pressing `y` confirms the skip and sends SIGTERM to the subprocess; pressing `n` or `Esc` cancels. See [Recovering from Step Failures](recovering-from-step-failures.md) for how skips interact with the workflow.
 - **`Esc` in Normal or Error mode** — Escape only cancels a quit confirmation. Outside of `ModeQuitConfirm`, it's ignored.
 
 ## Related documentation

--- a/docs/how-to/reading-the-tui.md
+++ b/docs/how-to/reading-the-tui.md
@@ -25,7 +25,7 @@ The screen is assembled row-by-row in `Model.View()` inside a hand-built rounded
 │ [test-writing subprocess output streams here]       │
 │                                                     │
 ├─────────────────────────────────────────────────────┤  ← HRule (T-junctions)
-│ ↑/k up  ↓/j down  n next step  q quit  ralph-tui v0.2.1 │  ← shortcut footer + version
+│ ↑/k up  ↓/j down  n next step  q quit  ralph-tui v0.4.1 │  ← shortcut footer + version
 ╰─────────────────────────────────────────────────────╯
 ```
 
@@ -141,7 +141,7 @@ Ralph completed after 2 iteration(s) and 2 finalizing tasks.
 | `Captured VAR = "value"` | Logged after any step with `captureAs`, showing the bound value |
 | `N turns · in/out tokens (cache: C/R) · $cost · duration` | Per-step summary emitted after each `isClaude: true` step completes; shows token spend, cost, and wall-clock duration for that single invocation |
 | `total claude spend across N step invocation[s]...` | Run-level cumulative summary: total token spend, cost, duration, and retry count across all claude steps; omitted when no claude steps ran |
-| `Ralph completed after N iteration(s) and M finalizing tasks.` | The final line of the run, written before the workflow goroutine calls `program.Quit()` and exits |
+| `Ralph completed after N iteration(s) and M finalizing tasks.` | The final line of the run, written before the workflow goroutine enters `ModeDone` |
 
 Phase banners use `═` (double horizontal) and are full-width; per-step banners use `─` (single horizontal) and match the heading width. This three-tier hierarchy — phase > iteration > step — lets you visually trace where you are in the log at a glance.
 
@@ -174,10 +174,12 @@ The left-side shortcut bar is the clearest way to tell what state the handler is
 |-------------|------|
 | `↑/k up  ↓/j down  n next step  q quit` | Normal — a step is running; you can scroll or skip |
 | `c continue  r retry  q quit` | Error — a step failed; you need to decide what to do |
-| `Quit Power-Ralph.9000? (y/n, esc to cancel)` | QuitConfirm — you pressed `q`, waiting for confirmation |
+| `Skip current step? (y/n, esc to cancel)` | NextConfirm — you pressed `n`, waiting for skip confirmation |
+| `Quit Power-Ralph.9000? (y/n, esc to cancel)` | QuitConfirm — you pressed `q`, waiting for quit confirmation |
+| `q quit` | Done — the workflow finished; review output, then press `q` → `y` to exit |
 | `Quitting...` | Quitting — you confirmed the quit, shutdown is unwinding |
 
-When the workflow finishes normally, the completion summary is written to the log body and the process exits on its own — no final keypress required.
+When the workflow finishes normally, the completion summary is written to the log body and the TUI enters `ModeDone` with a `q quit` footer. The process does not exit on its own — press `q` then `y` to exit, giving you time to review the final output.
 
 See [Recovering from Step Failures](recovering-from-step-failures.md) for the Error-mode decision tree and [Quitting Gracefully](quitting-gracefully.md) for the quit flow.
 
@@ -185,7 +187,7 @@ See [Recovering from Step Failures](recovering-from-step-failures.md) for the Er
 
 - [Getting Started](getting-started.md) — Install and first-run walk-through
 - [TUI Status Header & Log Display](../features/tui-display.md) — Implementation details: StatusHeader struct, log helpers, terminal width detection
-- [Keyboard Input & Error Recovery](../features/keyboard-input.md) — Four-mode state machine that drives the footer
+- [Keyboard Input & Error Recovery](../features/keyboard-input.md) — Six-mode state machine that drives the footer
 - [Workflow Orchestration](../features/workflow-orchestration.md) — Where the log chrome comes from — what `Run` writes, what `Orchestrate` writes
 - [Recovering from Step Failures](recovering-from-step-failures.md) — Error-mode keyboard controls
 - [Quitting Gracefully](quitting-gracefully.md) — Quit-confirm, Escape cancel, SIGINT

--- a/docs/how-to/recovering-from-step-failures.md
+++ b/docs/how-to/recovering-from-step-failures.md
@@ -96,7 +96,7 @@ If you leave the workflow paused and walk away, nothing bad happens — no timeo
 
 ### The step terminated itself
 
-If you pressed `n` **during** the step to skip it, the subprocess gets a SIGTERM (then SIGKILL after 3 seconds). The non-zero exit is treated as a **successful termination** (`WasTerminated() == true`) and the step is marked `[✓]` — no error mode, no pause, just advance. This is the mechanism behind "skip this step".
+If you pressed `n` **during** the step to skip it, a confirmation prompt appears (`Skip current step? y/n, esc to cancel`). Pressing `y` confirms the skip: the subprocess gets a SIGTERM (then SIGKILL after 3 seconds). The non-zero exit is treated as a **successful termination** (`WasTerminated() == true`) and the step is marked `[✓]` — no error mode, no pause, just advance. Pressing `n` or `Esc` cancels the skip and returns to normal mode. This is the mechanism behind "skip this step".
 
 ### `buildStep` failed before the subprocess could start
 

--- a/docs/how-to/setting-up-docker-sandbox.md
+++ b/docs/how-to/setting-up-docker-sandbox.md
@@ -257,4 +257,5 @@ This happens when the `-u` flag is not taking effect (e.g., an older Docker imag
 - [sandbox Subcommand Feature Doc](../features/sandbox-subcommand.md) — Implementation details of the `sandbox create` and `sandbox login` subcommands
 - [Preflight Feature Doc](../features/preflight.md) — Startup checks that enforce sandbox readiness
 - [ADR: Require Docker Sandbox](../adr/20260413160000-require-docker-sandbox.md) — Decision rationale for making Docker a runtime requirement
+- [Passing Environment Variables](passing-environment-variables.md) — How to forward host env vars (API tokens, proxy settings) into the sandbox
 - [Recovering from Step Failures](recovering-from-step-failures.md) — Retry/continue decisions when a step fails inside the sandbox

--- a/docs/plans/command-confirmation/design.md
+++ b/docs/plans/command-confirmation/design.md
@@ -1,0 +1,319 @@
+# Plan: Add `n` confirmation and post-workflow "Press q to quit"
+
+## Context
+
+Currently, pressing `n` in the TUI immediately kills the running subprocess with no confirmation. Also, when the workflow completes, `program.Quit()` is called immediately — the screen goes blank and the user can't review output. Two changes are needed:
+
+1. **`n` key confirmation** — show "Skip current step? (y/n, esc to cancel)" before canceling
+2. **Post-workflow done mode** — keep the TUI alive after workflow completion with a "q quit" footer, then go through the normal quit confirmation to exit
+
+## Approach
+
+Add two new modes to the keyboard state machine: `ModeNextConfirm` and `ModeDone`.
+
+### Files to modify
+
+- `ralph-tui/internal/ui/ui.go` — new modes, constants, shortcut line mapping
+- `ralph-tui/internal/ui/keys.go` — new handlers, updated dispatch and `handleNormal`
+- `ralph-tui/internal/ui/model.go` — `colorShortcutLine` for new prompt
+- `ralph-tui/cmd/ralph-tui/main.go` — workflow goroutine, signal handler restructure
+- `ralph-tui/internal/ui/keys_test.go` — new mode tests
+- `ralph-tui/internal/ui/ui_test.go` — SetMode tests for new modes, updated concurrent test
+- `ralph-tui/internal/ui/model_test.go` — update `TestNormalMode_N_ReturnsCancelCmd`
+
+### Step 1: `ui.go` — Add modes and constants
+
+Add `ModeNextConfirm` and `ModeDone` to the Mode enum (between `ModeQuitConfirm` and `ModeQuitting`):
+
+```go
+ModeQuitConfirm
+ModeNextConfirm  // NEW
+ModeDone         // NEW
+ModeQuitting
+```
+
+Add new string constants:
+
+```go
+NextConfirmPrompt = "Skip current step? (y/n, esc to cancel)"
+DoneShortcuts     = "q quit"
+```
+
+Add cases to `updateShortcutLineLocked`:
+
+```go
+case ModeNextConfirm:
+    h.shortcutLine = NextConfirmPrompt
+case ModeDone:
+    h.shortcutLine = DoneShortcuts
+```
+
+### Step 2: `keys.go` — New handlers and updated dispatch
+
+**Update `keysModel.Update` dispatch** — add two new cases:
+
+```go
+case ModeNextConfirm:
+    return m.handleNextConfirm(key)
+case ModeDone:
+    return m.handleDone(key)
+```
+
+**Change `handleNormal` `n` case** — instead of calling `cancel()` directly, enter `ModeNextConfirm` (same pattern as `q` entering `ModeQuitConfirm`):
+
+```go
+case "n":
+    cancel := m.handler.Cancel()
+    if cancel == nil {
+        return m, nil
+    }
+    m.handler.mu.Lock()
+    m.handler.prevMode = m.handler.mode
+    m.handler.mode = ModeNextConfirm
+    m.handler.updateShortcutLineLocked()
+    m.handler.mu.Unlock()
+    return m, nil
+```
+
+Note: the `cancel` nil check gates entry to `ModeNextConfirm`. If cancel is nil (no subprocess running), pressing `n` is a no-op — same as before.
+
+**Add `handleNextConfirm`**:
+- `y`: re-acquire `cancel` via `m.handler.Cancel()`, restore prevMode, then offload `cancel()` via tea.Cmd (same goroutine-offload pattern as the old `handleNormal` `n` case). Re-acquiring `cancel` is safe because the subprocess is still running while we're in `ModeNextConfirm` — the workflow goroutine doesn't advance steps until the current step finishes or is terminated.
+- `n`/`esc`: restore prevMode (same pattern as `handleQuitConfirm`)
+
+```go
+func (m keysModel) handleNextConfirm(key tea.KeyMsg) (keysModel, tea.Cmd) {
+    switch key.String() {
+    case "y":
+        cancel := m.handler.Cancel()
+        m.handler.mu.Lock()
+        m.handler.mode = m.handler.prevMode
+        m.handler.updateShortcutLineLocked()
+        m.handler.mu.Unlock()
+        if cancel == nil {
+            return m, nil
+        }
+        return m, func() tea.Msg {
+            cancel()
+            return nil
+        }
+    case "n", "esc":
+        m.handler.mu.Lock()
+        m.handler.mode = m.handler.prevMode
+        m.handler.updateShortcutLineLocked()
+        m.handler.mu.Unlock()
+    }
+    return m, nil
+}
+```
+
+**Add `handleDone`**:
+- `q`: enter `ModeQuitConfirm` with `prevMode = ModeDone` (same pattern as `handleNormal` `q`)
+- All other keys: no-op
+
+```go
+func (m keysModel) handleDone(key tea.KeyMsg) (keysModel, tea.Cmd) {
+    switch key.String() {
+    case "q":
+        m.handler.mu.Lock()
+        m.handler.prevMode = m.handler.mode
+        m.handler.mode = ModeQuitConfirm
+        m.handler.updateShortcutLineLocked()
+        m.handler.mu.Unlock()
+    }
+    return m, nil
+}
+```
+
+### Step 3: `keys.go` — Make quit confirmation exit the TUI
+
+**Update `handleQuitConfirm` `y` case** — return `tea.QuitMsg{}` instead of `nil` from the cmd function:
+
+```go
+return m, func() tea.Msg {
+    m.handler.ForceQuit()
+    return tea.QuitMsg{}  // was: return nil
+}
+```
+
+This is needed because in `ModeDone`, there's no workflow goroutine to call `program.Quit()`. The existing `Model.Update` already handles `tea.QuitMsg` at model.go:148-149 and returns `tea.Quit`. For the mid-workflow quit case, `tea.QuitMsg` causes `program.Run()` to return before the workflow goroutine finishes cleanup — the `workflowDone` wait added to `main.go` in Step 5 ensures logs are flushed and channels are closed before `os.Exit`.
+
+### Step 4: `model.go` — Update `colorShortcutLine`
+
+Add a case for `NextConfirmPrompt` (render all-white, same as `QuittingLine`):
+
+```go
+if s == NextConfirmPrompt {
+    return white.Render(s)
+}
+```
+
+Place this after the `QuitConfirmPrompt` block and before the `QuittingLine` check. `DoneShortcuts` ("q quit") naturally works with the existing default two-tone rendering (key white, description gray) — no special case needed.
+
+### Step 5: `main.go` — Workflow goroutine and signal handler restructure
+
+This step requires careful changes because the TUI stays alive after the workflow finishes, and signals must remain handled during `ModeDone` to avoid corrupting the terminal.
+
+**Problem**: The current signal handler goroutine exits via `case <-workflowDone:` when the workflow completes. The workflow goroutine calls `signal.Stop(sigChan)` before calling `program.Quit()`. If we simply replace `program.Quit()` with `SetMode(ModeDone)`, SIGINT/SIGTERM during `ModeDone` would hit the OS default handler (immediate kill), leaving the terminal in alt-screen mode because Bubble Tea cleanup never runs.
+
+**Solution**: Restructure the signal handler goroutine to remain active after workflow completion, and move `signal.Stop(sigChan)` out of the workflow goroutine.
+
+**Workflow goroutine** — change from:
+
+```go
+go func() {
+    defer close(workflowDone)
+    _ = workflow.Run(runner, proxy, keyHandler, runCfg)
+    signal.Stop(sigChan)
+    _ = log.Close()
+    close(lineCh)
+    program.Quit()
+}()
+```
+
+to:
+
+```go
+go func() {
+    defer close(workflowDone)
+    _ = workflow.Run(runner, proxy, keyHandler, runCfg)
+    _ = log.Close()
+    close(lineCh)
+    keyHandler.SetMode(ui.ModeDone)
+}()
+```
+
+Remove `signal.Stop(sigChan)` — signals stay registered until the process exits. Remove `program.Quit()` — the TUI stays alive in `ModeDone`.
+
+**Signal handler goroutine** — change from:
+
+```go
+go func() {
+    select {
+    case <-sigChan:
+        close(signaled)
+        keyHandler.ForceQuit()
+        select {
+        case <-workflowDone:
+        case <-time.After(2 * time.Second):
+            program.Kill()
+        }
+    case <-workflowDone:
+    }
+}()
+```
+
+to:
+
+```go
+go func() {
+    <-sigChan
+    close(signaled)
+    keyHandler.ForceQuit()
+    select {
+    case <-workflowDone:
+    case <-time.After(2 * time.Second):
+    }
+    program.Kill()
+}()
+```
+
+The signal handler now:
+1. Blocks on `<-sigChan` unconditionally (no `case <-workflowDone:` escape hatch)
+2. On signal: calls `ForceQuit()`, waits up to 2s for workflow to finish
+3. Always calls `program.Kill()` at the end
+
+If the signal arrives during `ModeDone` (workflow already finished):
+- `ForceQuit()` sets `ModeQuitting`, calls `runner.Terminate()` (no-op — no subprocess), sends `ActionQuit` (non-blocking, nobody reads)
+- `<-workflowDone` resolves immediately (already closed)
+- `program.Kill()` force-stops the TUI, restoring terminal state
+
+If no signal ever arrives: the goroutine stays blocked on `<-sigChan` forever. This is fine — the process exits when `program.Run()` returns (via user `q` → `y` → `tea.QuitMsg`), and the goroutine is cleaned up by process exit. The goroutine is lightweight (blocked on channel) and does not leak resources.
+
+**After `program.Run()` returns** — add `signal.Stop(sigChan)` and a wait for `workflowDone` before exit codes:
+
+```go
+_, runErr := program.Run()
+signal.Stop(sigChan)
+
+// Wait for the workflow goroutine to finish cleanup (log flush, channel
+// close). Needed because handleQuitConfirm's tea.QuitMsg can cause
+// program.Run() to return before the workflow goroutine finishes — the
+// mid-workflow quit path sends tea.QuitMsg immediately after ForceQuit,
+// racing with the goroutine's log.Close() and close(lineCh).
+select {
+case <-workflowDone:
+case <-time.After(4 * time.Second):
+}
+
+// ... existing error handling and exit codes ...
+```
+
+`signal.Stop(sigChan)` deregisters signal notifications after the TUI has exited cleanly. The `workflowDone` wait ensures the workflow goroutine's cleanup (log flush, channel close) completes before `os.Exit`. The 4-second timeout exceeds the 3-second `terminateGracePeriod` in `runner.Terminate()` plus buffer for `log.Close()` and `close(lineCh)` — this prevents `os.Exit` from firing while SIGTERM→SIGKILL is still in progress during a mid-workflow quit. Both align with the concurrency coding standard ("Signal path and completion path must converge cleanly" and "Wait for background goroutines after program.Run() returns").
+
+### Step 6: Update tests
+
+**`keys_test.go`**:
+- `TestHandleNormal_N_NilCancel_NoCmd`: no change needed — nil cancel still returns early before entering `ModeNextConfirm`
+- Add `TestHandleNormal_N_EntersNextConfirm`: press `n` with non-nil cancel, verify `ModeNextConfirm` and `NextConfirmPrompt` shortcut line, and nil cmd return
+- Add `TestHandleNormal_N_SavesPrevModeAsNormal`: verify prevMode is `ModeNormal` after `n` transitions to `ModeNextConfirm`
+- Add `TestHandleNextConfirm_Y_RestoresModeAndReturnsCmd`: enter `ModeNextConfirm` from `ModeNormal` via `n`, press `y`, verify mode restored to `ModeNormal`, non-nil cmd returned, executing cmd calls cancel
+- Add `TestHandleNextConfirm_N_RevertsMode`: enter `ModeNextConfirm`, press `n`, verify mode reverted and `NormalShortcuts` restored
+- Add `TestHandleNextConfirm_Esc_RevertsMode`: same with esc key
+- Add `TestHandleNextConfirm_UnrecognizedKey_NoOp`: press `x`, verify no mode change
+- Add `TestHandleDone_Q_EntersQuitConfirm`: set `ModeDone`, press `q`, verify `ModeQuitConfirm` with `prevMode=ModeDone`
+- Add `TestHandleDone_Q_SavesPrevModeAsDone`: verify prevMode after transition
+- Add `TestHandleDone_OtherKeys_NoOp`: press `n`, `c`, `r`, `x` — all no-op
+- Update `TestHandleQuitConfirm_Y_ReturnsNonNilCmd`: verify cmd returns `tea.QuitMsg{}`
+- Add `TestHandleQuitConfirm_Esc_FromDone_RevertsToDone`: enter quit-confirm from `ModeDone`, press esc, verify mode reverts to `ModeDone` and `DoneShortcuts` restored
+
+**`ui_test.go`**:
+- Add `TestSetMode_NextConfirm_UpdatesShortcutLine`: verify `NextConfirmPrompt`
+- Add `TestSetMode_Done_UpdatesShortcutLine`: verify `DoneShortcuts`
+- Add `TestForceQuit_SetsModeQuitting_FromNextConfirm`: set `ModeNextConfirm`, call `ForceQuit()`, verify `ModeQuitting` and `QuittingLine` (matches existing `_FromNormal` and `_FromError` pattern — covers SIGINT during the skip confirmation prompt)
+- Add `TestForceQuit_SetsModeQuitting_FromDone`: set `ModeDone`, call `ForceQuit()`, verify `ModeQuitting` and `QuittingLine` (covers SIGINT during the post-workflow done screen)
+- Update `TestShortcutLine_ConcurrentRead_NoRace`: add `ModeNextConfirm` and `ModeDone` to the mode cycle
+- Update `TestForceQuit_ConcurrentAccess_NoRace`: add `ModeNextConfirm` and `ModeDone` to the SetMode cycle
+
+**`model_test.go`**:
+- Rewrite `TestNormalMode_N_ReturnsCancelCmd` as `TestNormalMode_N_ThenY_CallsCancel`: press `n` (enters `ModeNextConfirm`, nil cmd), then press `y` (returns non-nil cmd that calls cancel). Two-step test.
+- Add `TestColorShortcutLine_NextConfirmPrompt_PreservesText`: verify plain text matches `NextConfirmPrompt`
+- Add `TestColorShortcutLine_DoneShortcuts_PreservesText`: verify plain text matches `DoneShortcuts`
+
+### Step 7: Update concurrency coding standard
+
+Update `docs/coding-standards/concurrency.md`:
+
+1. **"Signal path and completion path must converge cleanly"** — the code example shows `program.Quit()` in the workflow goroutine. Update the example to show `SetMode(ModeDone)` and the restructured signal handler, so the standard matches the new implementation.
+
+2. **"Wait for background goroutines after program.Run() returns"** — the code example is missing the `signal.Stop(sigChan)` call that now lives after `program.Run()`. Update the example to show `signal.Stop(sigChan)` followed by the `workflowDone` select, so the standard documents the full post-Run shutdown sequence.
+
+### Step 8: Update feature documentation
+
+- `docs/features/keyboard-input.md` — update "Four-mode keyboard state machine" to six modes; add `ModeNextConfirm` (n confirmation) and `ModeDone` (post-workflow) to the state diagram and mode descriptions
+- `docs/features/signal-handling.md` — update the signal handler description to reflect the restructured goroutine (unconditional `<-sigChan` block, no `workflowDone` escape hatch, always `program.Kill()` at the end)
+- `docs/features/tui-display.md` — add `NextConfirmPrompt` and `DoneShortcuts` to the shortcut footer section
+
+## Verification
+
+1. `cd ralph-tui && go test -race ./...` — all tests pass
+2. `make lint` — no lint issues
+3. `make build` — builds successfully
+4. Manual: run against a project, press `n` during a step — see confirmation prompt, `y` skips, `esc` cancels
+5. Manual: let workflow complete — TUI stays up with "q quit" footer, press `q` then `y` to exit
+6. Manual: let workflow complete — in `ModeDone`, press Ctrl+C — TUI exits cleanly, terminal restored
+7. Manual: during a running step, press `q` then `y` — TUI exits after subprocess terminates
+
+## Review summary
+
+- Iterations completed: 3 + agent validation
+- Assumptions challenged: 11 primary + secondary across iterations; 6 verified by evidence-based investigator; 8 examined by adversarial validator
+- Consolidations: 0
+- Changes from iterations:
+  - **Critical**: Added `workflowDone` wait after `program.Run()` — without it, `os.Exit` races the workflow goroutine's log flush and channel close during mid-workflow quit
+  - **Critical**: Set post-Run timeout to 4s (not 2s) — must exceed the 3s `terminateGracePeriod` in `runner.Terminate()` to prevent `os.Exit` during SIGTERM→SIGKILL
+  - **Test gap**: Added `TestForceQuit_SetsModeQuitting_FromNextConfirm` and `_FromDone` — covers SIGINT arriving during new modes (flagged by adversarial validator)
+  - Updated Step 3 text to accurately describe mid-workflow quit timing
+  - Expanded Step 7 to include "Wait for background goroutines" standard update
+  - Added Step 8 for feature documentation updates
+- Inherited from original plan: signal handler restructured to remain active during `ModeDone`

--- a/docs/project-discovery.md
+++ b/docs/project-discovery.md
@@ -28,7 +28,7 @@
 - Package manager: Go modules
 - Dependency manifest: `ralph-tui/go.mod`
 - Module: `github.com/mxriverlynn/pr9k/ralph-tui`
-- Current version: `0.3.1` (single source of truth: `ralph-tui/internal/version/version.go`)
+- Current version: `0.4.1` (single source of truth: `ralph-tui/internal/version/version.go`)
 - External dependencies: `github.com/charmbracelet/bubbletea` v1.3.10 (TUI framework), `github.com/charmbracelet/lipgloss` v1.1.0 (styling), `github.com/charmbracelet/bubbles` v1.0.0 (viewport widget), `github.com/spf13/cobra` v1.10.2, `golang.org/x/sys` v0.40.0
 
 ### Frameworks and Tooling
@@ -79,6 +79,7 @@
 - **How-To Guides:**
   - [Building Custom Workflows](how-to/building-custom-workflows.md) — Creating custom step sequences, adding prompts, mixing Claude and shell steps
   - [Variable Output & Injection](how-to/variable-output-and-injection.md) — Variable injection into prompts/commands and file-based data passing between steps
+  - [Passing Environment Variables](how-to/passing-environment-variables.md) — Forwarding host env vars into the Docker sandbox via the `env` field
 - **Coding Standards** — Conventions governing Go code in ralph-tui:
   - [API Design](coding-standards/api-design.md), [Concurrency](coding-standards/concurrency.md), [Error Handling](coding-standards/error-handling.md), [Go Patterns](coding-standards/go-patterns.md), [Testing](coding-standards/testing.md), [Lint and Tooling](coding-standards/lint-and-tooling.md), [Versioning](coding-standards/versioning.md)
 - [ralph-tui Plan](plans/ralph-tui.md) — Original specification and design rationale

--- a/ralph-tui/cmd/ralph-tui/main.go
+++ b/ralph-tui/cmd/ralph-tui/main.go
@@ -230,31 +230,38 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	signaled := make(chan struct{})
 	go func() {
+		<-sigChan
+		close(signaled)
+		keyHandler.ForceQuit()
 		select {
-		case <-sigChan:
-			close(signaled)
-			keyHandler.ForceQuit()
-			// Give the workflow goroutine up to 2 seconds to exit cleanly.
-			select {
-			case <-workflowDone:
-			case <-time.After(2 * time.Second):
-				program.Kill()
-			}
 		case <-workflowDone:
+		case <-time.After(2 * time.Second):
 		}
+		program.Kill()
 	}()
 
 	// Workflow goroutine: run the full workflow, then tear down cleanly.
 	go func() {
 		defer close(workflowDone)
 		_ = workflow.Run(runner, proxy, keyHandler, runCfg)
-		signal.Stop(sigChan)
 		_ = log.Close()
 		close(lineCh)
-		program.Quit()
+		keyHandler.SetMode(ui.ModeDone)
 	}()
 
 	_, runErr := program.Run()
+	signal.Stop(sigChan)
+
+	// Wait for the workflow goroutine to finish cleanup (log flush, channel
+	// close). Needed because handleQuitConfirm's tea.QuitMsg can cause
+	// program.Run() to return before the workflow goroutine finishes — the
+	// mid-workflow quit path sends tea.QuitMsg immediately after ForceQuit,
+	// racing with the goroutine's log.Close() and close(lineCh).
+	select {
+	case <-workflowDone:
+	case <-time.After(4 * time.Second):
+	}
+
 	// program.Kill() (signal-path forced shutdown after 2s grace) causes Run
 	// to return tea.ErrProgramKilled. That is a normal forced-exit path, not
 	// a crash — don't print a scary error for it.

--- a/ralph-tui/internal/ui/keys.go
+++ b/ralph-tui/internal/ui/keys.go
@@ -29,6 +29,10 @@ func (m keysModel) Update(msg tea.Msg) (keysModel, tea.Cmd) {
 		return m.handleError(key)
 	case ModeQuitConfirm:
 		return m.handleQuitConfirm(key)
+	case ModeNextConfirm:
+		return m.handleNextConfirm(key)
+	case ModeDone:
+		return m.handleDone(key)
 	case ModeQuitting:
 		// All keys silently ignored so a user mashing keys during shutdown
 		// can't inject a second ActionQuit or retrigger the cancel hook.
@@ -44,15 +48,12 @@ func (m keysModel) handleNormal(key tea.KeyMsg) (keysModel, tea.Cmd) {
 		if cancel == nil {
 			return m, nil
 		}
-		// Offload the 3-second blocking Terminate call to a goroutine via
-		// tea.Cmd so the Update goroutine is not frozen while waiting for
-		// SIGTERM / SIGKILL to propagate. We don't need a result message —
-		// the workflow goroutine's next RunStep will observe WasTerminated
-		// and unwind on its own.
-		return m, func() tea.Msg {
-			cancel()
-			return nil // Bubble Tea ignores nil messages
-		}
+		m.handler.mu.Lock()
+		m.handler.prevMode = m.handler.mode
+		m.handler.mode = ModeNextConfirm
+		m.handler.updateShortcutLineLocked()
+		m.handler.mu.Unlock()
+		return m, nil
 	case "q":
 		m.handler.mu.Lock()
 		m.handler.prevMode = m.handler.mode
@@ -85,6 +86,42 @@ func (m keysModel) handleError(key tea.KeyMsg) (keysModel, tea.Cmd) {
 	return m, nil
 }
 
+func (m keysModel) handleNextConfirm(key tea.KeyMsg) (keysModel, tea.Cmd) {
+	switch key.String() {
+	case "y":
+		cancel := m.handler.Cancel()
+		m.handler.mu.Lock()
+		m.handler.mode = m.handler.prevMode
+		m.handler.updateShortcutLineLocked()
+		m.handler.mu.Unlock()
+		if cancel == nil {
+			return m, nil
+		}
+		return m, func() tea.Msg {
+			cancel()
+			return nil
+		}
+	case "n", "esc":
+		m.handler.mu.Lock()
+		m.handler.mode = m.handler.prevMode
+		m.handler.updateShortcutLineLocked()
+		m.handler.mu.Unlock()
+	}
+	return m, nil
+}
+
+func (m keysModel) handleDone(key tea.KeyMsg) (keysModel, tea.Cmd) {
+	switch key.String() {
+	case "q":
+		m.handler.mu.Lock()
+		m.handler.prevMode = m.handler.mode
+		m.handler.mode = ModeQuitConfirm
+		m.handler.updateShortcutLineLocked()
+		m.handler.mu.Unlock()
+	}
+	return m, nil
+}
+
 func (m keysModel) handleQuitConfirm(key tea.KeyMsg) (keysModel, tea.Cmd) {
 	switch key.String() {
 	case "y":
@@ -92,10 +129,12 @@ func (m keysModel) handleQuitConfirm(key tea.KeyMsg) (keysModel, tea.Cmd) {
 		// tea.Cmd so the Update goroutine is not frozen. ForceQuit sets
 		// ModeQuitting internally under h.mu, so the footer updates on the
 		// next tick. ForceQuit is idempotent, so a second call from the
-		// signal path racing with y-confirm is harmless.
+		// signal path racing with y-confirm is harmless. Return tea.QuitMsg
+		// so the TUI exits even when there is no workflow goroutine to call
+		// program.Quit() (e.g. ModeDone).
 		return m, func() tea.Msg {
 			m.handler.ForceQuit()
-			return nil
+			return tea.QuitMsg{}
 		}
 	case "n", "esc":
 		m.handler.mu.Lock()

--- a/ralph-tui/internal/ui/keys_test.go
+++ b/ralph-tui/internal/ui/keys_test.go
@@ -197,6 +197,156 @@ func TestHandleError_UnrecognizedKey_NoOp(t *testing.T) {
 	}
 }
 
+// --- handleNextConfirm ---
+
+func TestHandleNormal_N_EntersNextConfirm(t *testing.T) {
+	h, _ := newKeysTestHandler(t, ModeNormal)
+	m := newKeysModel(h)
+
+	_, cmd := m.Update(keyMsg("n"))
+	if cmd != nil {
+		t.Error("expected nil cmd for n entering NextConfirm")
+	}
+	if h.Mode() != ModeNextConfirm {
+		t.Errorf("expected ModeNextConfirm, got %v", h.Mode())
+	}
+	if h.ShortcutLine() != NextConfirmPrompt {
+		t.Errorf("expected NextConfirmPrompt, got %q", h.ShortcutLine())
+	}
+}
+
+func TestHandleNormal_N_SavesPrevModeAsNormal(t *testing.T) {
+	h, _ := newKeysTestHandler(t, ModeNormal)
+	m := newKeysModel(h)
+
+	m.Update(keyMsg("n"))
+
+	h.mu.Lock()
+	prev := h.prevMode
+	h.mu.Unlock()
+
+	if prev != ModeNormal {
+		t.Errorf("expected prevMode ModeNormal, got %v", prev)
+	}
+}
+
+func TestHandleNextConfirm_Y_RestoresModeAndReturnsCmd(t *testing.T) {
+	cancelCalled := false
+	actions := make(chan StepAction, 10)
+	h := NewKeyHandler(func() { cancelCalled = true }, actions)
+	m := newKeysModel(h)
+
+	// Press n to enter ModeNextConfirm.
+	m.Update(keyMsg("n"))
+	if h.Mode() != ModeNextConfirm {
+		t.Fatalf("precondition: expected ModeNextConfirm, got %v", h.Mode())
+	}
+
+	// Press y to confirm skip.
+	_, cmd := m.Update(keyMsg("y"))
+	if h.Mode() != ModeNormal {
+		t.Errorf("expected mode restored to ModeNormal, got %v", h.Mode())
+	}
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for y in next-confirm mode")
+	}
+	_ = cmd()
+	if !cancelCalled {
+		t.Error("expected cancel to be called after y cmd execution")
+	}
+}
+
+func TestHandleNextConfirm_N_RevertsMode(t *testing.T) {
+	h, _ := newKeysTestHandler(t, ModeNormal)
+	m := newKeysModel(h)
+
+	m.Update(keyMsg("n")) // enter ModeNextConfirm
+	_, cmd := m.Update(keyMsg("n"))
+	if cmd != nil {
+		t.Error("expected nil cmd for n in next-confirm mode")
+	}
+	if h.Mode() != ModeNormal {
+		t.Errorf("expected mode reverted to ModeNormal, got %v", h.Mode())
+	}
+	if h.ShortcutLine() != NormalShortcuts {
+		t.Errorf("expected NormalShortcuts after n, got %q", h.ShortcutLine())
+	}
+}
+
+func TestHandleNextConfirm_Esc_RevertsMode(t *testing.T) {
+	h, _ := newKeysTestHandler(t, ModeNormal)
+	m := newKeysModel(h)
+
+	m.Update(keyMsg("n")) // enter ModeNextConfirm
+	escMsg := tea.KeyMsg{Type: tea.KeyEsc}
+	_, cmd := m.Update(escMsg)
+	if cmd != nil {
+		t.Error("expected nil cmd for esc in next-confirm mode")
+	}
+	if h.Mode() != ModeNormal {
+		t.Errorf("expected mode reverted to ModeNormal, got %v", h.Mode())
+	}
+}
+
+func TestHandleNextConfirm_UnrecognizedKey_NoOp(t *testing.T) {
+	h, _ := newKeysTestHandler(t, ModeNormal)
+	m := newKeysModel(h)
+
+	m.Update(keyMsg("n")) // enter ModeNextConfirm
+	_, cmd := m.Update(keyMsg("x"))
+	if cmd != nil {
+		t.Error("expected nil cmd for unrecognized key in next-confirm mode")
+	}
+	if h.Mode() != ModeNextConfirm {
+		t.Errorf("mode changed unexpectedly: got %v", h.Mode())
+	}
+}
+
+// --- handleDone ---
+
+func TestHandleDone_Q_EntersQuitConfirm(t *testing.T) {
+	h, _ := newKeysTestHandler(t, ModeDone)
+	m := newKeysModel(h)
+
+	_, cmd := m.Update(keyMsg("q"))
+	if cmd != nil {
+		t.Error("expected nil cmd for q in done mode")
+	}
+	if h.Mode() != ModeQuitConfirm {
+		t.Errorf("expected ModeQuitConfirm, got %v", h.Mode())
+	}
+}
+
+func TestHandleDone_Q_SavesPrevModeAsDone(t *testing.T) {
+	h, _ := newKeysTestHandler(t, ModeDone)
+	m := newKeysModel(h)
+
+	m.Update(keyMsg("q"))
+
+	h.mu.Lock()
+	prev := h.prevMode
+	h.mu.Unlock()
+
+	if prev != ModeDone {
+		t.Errorf("expected prevMode ModeDone, got %v", prev)
+	}
+}
+
+func TestHandleDone_OtherKeys_NoOp(t *testing.T) {
+	for _, key := range []string{"n", "c", "r", "x"} {
+		h, _ := newKeysTestHandler(t, ModeDone)
+		m := newKeysModel(h)
+
+		_, cmd := m.Update(keyMsg(key))
+		if cmd != nil {
+			t.Errorf("expected nil cmd for %q in done mode", key)
+		}
+		if h.Mode() != ModeDone {
+			t.Errorf("mode changed unexpectedly on %q: got %v", key, h.Mode())
+		}
+	}
+}
+
 // --- TP-002: handleQuitConfirm ---
 
 func TestHandleQuitConfirm_Y_ReturnsNonNilCmd(t *testing.T) {
@@ -207,10 +357,31 @@ func TestHandleQuitConfirm_Y_ReturnsNonNilCmd(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected non-nil cmd for y in quit-confirm mode")
 	}
-	// Executing the cmd calls ForceQuit, which sets ModeQuitting.
-	_ = cmd()
+	// Executing the cmd calls ForceQuit (sets ModeQuitting) and returns tea.QuitMsg.
+	result := cmd()
 	if h.Mode() != ModeQuitting {
 		t.Errorf("expected ModeQuitting after executing y cmd, got %v", h.Mode())
+	}
+	if _, ok := result.(tea.QuitMsg); !ok {
+		t.Errorf("expected tea.QuitMsg from y cmd, got %T", result)
+	}
+}
+
+func TestHandleQuitConfirm_Esc_FromDone_RevertsToDone(t *testing.T) {
+	h, _ := newKeysTestHandler(t, ModeDone)
+	m := newKeysModel(h)
+
+	m.Update(keyMsg("q")) // enter QuitConfirm from Done
+	escMsg := tea.KeyMsg{Type: tea.KeyEsc}
+	_, cmd := m.Update(escMsg)
+	if cmd != nil {
+		t.Error("expected nil cmd for esc in quit-confirm mode")
+	}
+	if h.Mode() != ModeDone {
+		t.Errorf("expected mode reverted to ModeDone, got %v", h.Mode())
+	}
+	if h.ShortcutLine() != DoneShortcuts {
+		t.Errorf("expected DoneShortcuts after esc, got %q", h.ShortcutLine())
 	}
 }
 

--- a/ralph-tui/internal/ui/model.go
+++ b/ralph-tui/internal/ui/model.go
@@ -304,6 +304,9 @@ func colorShortcutLine(s string) string {
 		}
 		return white.Render(s)
 	}
+	if s == NextConfirmPrompt {
+		return white.Render(s)
+	}
 	if s == QuittingLine {
 		return white.Render(s)
 	}

--- a/ralph-tui/internal/ui/model_test.go
+++ b/ralph-tui/internal/ui/model_test.go
@@ -124,7 +124,7 @@ func TestLogLines_ScrolledUp_DoesNotAutoScroll(t *testing.T) {
 
 // --- Normal-mode 'n' key routing ---
 
-func TestNormalMode_N_ReturnsCancelCmd(t *testing.T) {
+func TestNormalMode_N_ThenY_CallsCancel(t *testing.T) {
 	cancelCalled := false
 	actions := make(chan StepAction, 10)
 	kh := NewKeyHandler(func() { cancelCalled = true }, actions)
@@ -132,16 +132,24 @@ func TestNormalMode_N_ReturnsCancelCmd(t *testing.T) {
 	header.SetPhaseSteps([]string{"s"})
 	m := NewModel(header, kh, "v0")
 
-	// Press 'n' in normal mode.
-	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
-
-	if cmd == nil {
-		t.Fatal("expected non-nil cmd for n in normal mode")
+	// Press 'n' — enters ModeNextConfirm, nil cmd.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	m = next.(Model)
+	if cmd != nil {
+		t.Error("expected nil cmd for n entering NextConfirm")
 	}
-	// Execute the command — it should call cancel.
+	if kh.Mode() != ModeNextConfirm {
+		t.Fatalf("expected ModeNextConfirm after n, got %v", kh.Mode())
+	}
+
+	// Press 'y' — confirms skip, returns cmd that calls cancel.
+	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for y in next-confirm mode")
+	}
 	_ = cmd()
 	if !cancelCalled {
-		t.Error("expected cancel to be called after cmd execution")
+		t.Error("expected cancel to be called after y cmd execution")
 	}
 }
 
@@ -499,6 +507,22 @@ func TestColorShortcutLine_QuitConfirmPrompt_ContainsAppTitle(t *testing.T) {
 	}
 	if !strings.Contains(plain, AppTitle) {
 		t.Errorf("plain text missing AppTitle %q: %q", AppTitle, plain)
+	}
+}
+
+func TestColorShortcutLine_NextConfirmPrompt_PreservesText(t *testing.T) {
+	result := colorShortcutLine(NextConfirmPrompt)
+	plain := stripANSI(result)
+	if plain != NextConfirmPrompt {
+		t.Errorf("plain text mismatch: want %q, got %q", NextConfirmPrompt, plain)
+	}
+}
+
+func TestColorShortcutLine_DoneShortcuts_PreservesText(t *testing.T) {
+	result := colorShortcutLine(DoneShortcuts)
+	plain := stripANSI(result)
+	if plain != DoneShortcuts {
+		t.Errorf("plain text mismatch: want %q, got %q", DoneShortcuts, plain)
 	}
 }
 

--- a/ralph-tui/internal/ui/ui.go
+++ b/ralph-tui/internal/ui/ui.go
@@ -18,7 +18,9 @@ const (
 	ModeNormal Mode = iota
 	ModeError
 	ModeQuitConfirm
-	ModeQuitting // entered after the user confirms a quit; footer shows "Quitting..."
+	ModeNextConfirm // entered after the user presses n; shows "Skip current step?" prompt
+	ModeDone        // entered after the workflow completes; shows "q quit" footer
+	ModeQuitting    // entered after the user confirms a quit; footer shows "Quitting..."
 )
 
 // AppTitle is the canonical display name of the application. Use this
@@ -28,10 +30,12 @@ const (
 const AppTitle = "Power-Ralph.9000"
 
 const (
-	NormalShortcuts   = "↑/k up  ↓/j down  n next step  q quit"
-	ErrorShortcuts    = "c continue  r retry  q quit"
-	QuitConfirmPrompt = "Quit " + AppTitle + "? (y/n, esc to cancel)"
-	QuittingLine      = "Quitting..."
+	NormalShortcuts    = "↑/k up  ↓/j down  n next step  q quit"
+	ErrorShortcuts     = "c continue  r retry  q quit"
+	QuitConfirmPrompt  = "Quit " + AppTitle + "? (y/n, esc to cancel)"
+	NextConfirmPrompt  = "Skip current step? (y/n, esc to cancel)"
+	DoneShortcuts      = "q quit"
+	QuittingLine       = "Quitting..."
 )
 
 // KeyHandler is a state machine that tracks keyboard mode
@@ -131,6 +135,10 @@ func (h *KeyHandler) updateShortcutLineLocked() {
 		h.shortcutLine = ErrorShortcuts
 	case ModeQuitConfirm:
 		h.shortcutLine = QuitConfirmPrompt
+	case ModeNextConfirm:
+		h.shortcutLine = NextConfirmPrompt
+	case ModeDone:
+		h.shortcutLine = DoneShortcuts
 	case ModeQuitting:
 		h.shortcutLine = QuittingLine
 	default:

--- a/ralph-tui/internal/ui/ui.go
+++ b/ralph-tui/internal/ui/ui.go
@@ -30,12 +30,12 @@ const (
 const AppTitle = "Power-Ralph.9000"
 
 const (
-	NormalShortcuts    = "↑/k up  ↓/j down  n next step  q quit"
-	ErrorShortcuts     = "c continue  r retry  q quit"
-	QuitConfirmPrompt  = "Quit " + AppTitle + "? (y/n, esc to cancel)"
-	NextConfirmPrompt  = "Skip current step? (y/n, esc to cancel)"
-	DoneShortcuts      = "q quit"
-	QuittingLine       = "Quitting..."
+	NormalShortcuts   = "↑/k up  ↓/j down  n next step  q quit"
+	ErrorShortcuts    = "c continue  r retry  q quit"
+	QuitConfirmPrompt = "Quit " + AppTitle + "? (y/n, esc to cancel)"
+	NextConfirmPrompt = "Skip current step? (y/n, esc to cancel)"
+	DoneShortcuts     = "q quit"
+	QuittingLine      = "Quitting..."
 )
 
 // KeyHandler is a state machine that tracks keyboard mode

--- a/ralph-tui/internal/ui/ui_test.go
+++ b/ralph-tui/internal/ui/ui_test.go
@@ -145,6 +145,60 @@ func TestForceQuit_SetsModeQuitting_FromNormal(t *testing.T) {
 	}
 }
 
+// TestSetMode_NextConfirm_UpdatesShortcutLine verifies SetMode(ModeNextConfirm).
+func TestSetMode_NextConfirm_UpdatesShortcutLine(t *testing.T) {
+	h, _, _ := newTestHandler(t)
+
+	h.SetMode(ModeNextConfirm)
+
+	if h.ShortcutLine() != NextConfirmPrompt {
+		t.Errorf("expected NextConfirmPrompt, got %q", h.ShortcutLine())
+	}
+}
+
+// TestSetMode_Done_UpdatesShortcutLine verifies SetMode(ModeDone).
+func TestSetMode_Done_UpdatesShortcutLine(t *testing.T) {
+	h, _, _ := newTestHandler(t)
+
+	h.SetMode(ModeDone)
+
+	if h.ShortcutLine() != DoneShortcuts {
+		t.Errorf("expected DoneShortcuts, got %q", h.ShortcutLine())
+	}
+}
+
+// TestForceQuit_SetsModeQuitting_FromNextConfirm covers SIGINT during the skip
+// confirmation prompt.
+func TestForceQuit_SetsModeQuitting_FromNextConfirm(t *testing.T) {
+	h, _, _ := newTestHandler(t)
+	h.SetMode(ModeNextConfirm)
+
+	h.ForceQuit()
+
+	if h.Mode() != ModeQuitting {
+		t.Errorf("expected ModeQuitting after ForceQuit, got %v", h.Mode())
+	}
+	if h.ShortcutLine() != QuittingLine {
+		t.Errorf("expected QuittingLine after ForceQuit, got %q", h.ShortcutLine())
+	}
+}
+
+// TestForceQuit_SetsModeQuitting_FromDone covers SIGINT during the post-workflow
+// done screen.
+func TestForceQuit_SetsModeQuitting_FromDone(t *testing.T) {
+	h, _, _ := newTestHandler(t)
+	h.SetMode(ModeDone)
+
+	h.ForceQuit()
+
+	if h.Mode() != ModeQuitting {
+		t.Errorf("expected ModeQuitting after ForceQuit, got %v", h.Mode())
+	}
+	if h.ShortcutLine() != QuittingLine {
+		t.Errorf("expected QuittingLine after ForceQuit, got %q", h.ShortcutLine())
+	}
+}
+
 // TestForceQuit_SetsModeQuitting_FromError verifies that ForceQuit flips mode to
 // ModeQuitting and updates the footer even when called from ModeError (the signal path).
 func TestForceQuit_SetsModeQuitting_FromError(t *testing.T) {
@@ -219,8 +273,8 @@ func TestShortcutLine_ConcurrentRead_NoRace(t *testing.T) {
 		}
 	}()
 
-	// Workflow goroutine: cycle through all four modes for ≥500 iterations.
-	modes := []Mode{ModeNormal, ModeError, ModeQuitConfirm, ModeQuitting}
+	// Workflow goroutine: cycle through all six modes for ≥500 iterations.
+	modes := []Mode{ModeNormal, ModeError, ModeQuitConfirm, ModeNextConfirm, ModeDone, ModeQuitting}
 	for i := range 500 {
 		h.SetMode(modes[i%len(modes)])
 	}
@@ -265,8 +319,9 @@ func TestForceQuit_ConcurrentAccess_NoRace(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		modes := []Mode{ModeQuitConfirm, ModeNextConfirm, ModeDone}
 		for i := 0; i < 500; i++ {
-			h.SetMode(ModeQuitConfirm)
+			h.SetMode(modes[i%len(modes)])
 		}
 	}()
 

--- a/ralph-tui/internal/version/version.go
+++ b/ralph-tui/internal/version/version.go
@@ -4,4 +4,4 @@
 package version
 
 // Version is the current ralph-tui release version.
-const Version = "0.4.0"
+const Version = "0.4.1"


### PR DESCRIPTION
## Summary

Adds confirmation prompts to destructive TUI actions and a post-workflow "done" screen. Previously, pressing `n` immediately killed the running subprocess with no confirmation, and workflow completion called `program.Quit()` instantly — blanking the screen before the user could review output.

Two new modes are added to the keyboard state machine (expanding it from four to six modes):

- **`ModeNextConfirm`** — pressing `n` during a running step now shows `"Skip current step? (y/n, esc to cancel)"` instead of immediately terminating the subprocess. `y` confirms the skip, `n`/`Esc` cancel.
- **`ModeDone`** — when the workflow completes, the TUI stays alive with a `"q quit"` footer so the user can scroll through output. `q` → `y` exits cleanly via `tea.QuitMsg`.

The signal handler goroutine is restructured to remain active during `ModeDone` — it blocks unconditionally on `<-sigChan` (no `case <-workflowDone` escape hatch), so SIGINT/SIGTERM on the done screen still triggers `ForceQuit` + `program.Kill()` and restores the terminal. `handleQuitConfirm` now returns `tea.QuitMsg` so the TUI can exit even without a workflow goroutine calling `program.Quit()`. A 4-second `workflowDone` wait after `program.Run()` returns prevents `os.Exit` from racing the goroutine's log flush during mid-workflow quit.

Version bumped from `0.3.1` → `0.4.1`.

## Key file changes

| File | Change |
|------|--------|
| `ralph-tui/internal/ui/keys.go` | New `handleNextConfirm` and `handleDone` handlers; `handleNormal` `n` now enters `ModeNextConfirm` instead of calling cancel directly; `handleQuitConfirm` `y` returns `tea.QuitMsg` |
| `ralph-tui/internal/ui/ui.go` | Added `ModeNextConfirm`, `ModeDone` to Mode enum; new `NextConfirmPrompt`, `DoneShortcuts` constants; updated `updateShortcutLineLocked` |
| `ralph-tui/cmd/ralph-tui/main.go` | Workflow goroutine enters `ModeDone` instead of `program.Quit()`; signal handler blocks unconditionally; `signal.Stop` + 4s `workflowDone` wait after `program.Run()` |
| `ralph-tui/internal/ui/model.go` | `colorShortcutLine` handles `NextConfirmPrompt` (all-white rendering) |
| `ralph-tui/internal/version/version.go` | Version bump `0.3.1` → `0.4.1` |
| `docs/plans/command-confirmation/design.md` | Full design plan for both features with 8-step implementation |
| `docs/features/keyboard-input.md` | Rewritten for six-mode state machine with new diagrams |
| `docs/features/signal-handling.md` | Updated signal handler flow, `ModeDone` behavior, exit code selection |
| `docs/coding-standards/concurrency.md` | Updated code examples to match new shutdown paths |
| ... | +24 more files (see full diff) |

## Key test scenario changes

- ✅ `TestHandleNormal_N_EntersNextConfirm` — pressing `n` with active subprocess enters `ModeNextConfirm`
- ✅ `TestHandleNextConfirm_Y_RestoresModeAndReturnsCmd` — confirming skip calls cancel and restores previous mode
- ✅ `TestHandleNextConfirm_N_RevertsMode` / `_Esc_RevertsMode` — canceling skip returns to normal
- ✅ `TestHandleDone_Q_EntersQuitConfirm` — `q` from `ModeDone` enters quit confirmation with correct `prevMode`
- ✅ `TestHandleQuitConfirm_Y_ReturnsQuitMsg` — quit confirmation now returns `tea.QuitMsg`
- ✅ `TestForceQuit_SetsModeQuitting_FromNextConfirm` / `_FromDone` — SIGINT during new modes transitions to `ModeQuitting`
- ✅ Concurrent race tests updated to cycle through all six modes

### Test Files Changed

| File | Change |
|------|--------|
| `ralph-tui/internal/ui/keys_test.go` | Added tests for `ModeNextConfirm` and `ModeDone` handlers, updated quit-confirm test for `tea.QuitMsg` |
| `ralph-tui/internal/ui/ui_test.go` | Added `SetMode` and `ForceQuit` tests for new modes, updated concurrent race tests |
| `ralph-tui/internal/ui/model_test.go` | Rewrote `n`-key test as two-step (n then y), added `colorShortcutLine` tests for new prompts |

## Test Plan

- [ ] `cd ralph-tui && go test -race ./...` passes
- [ ] `make lint` passes
- [ ] `make build` succeeds
- [ ] Press `n` during a running step → confirmation prompt appears; `y` skips, `Esc` cancels
- [ ] Let workflow complete → TUI stays up with `q quit` footer; `q` → `y` exits
- [ ] SIGINT during `ModeDone` → terminal restored cleanly
- [ ] Mid-workflow `q` → `y` → TUI exits after subprocess terminates