### PR TITLE
Step Timeout Corrections

### DIFF
--- a/docs/code-packages/statusline.md
+++ b/docs/code-packages/statusline.md
@@ -167,7 +167,7 @@ type State struct {
 ```json
 {
   "sessionId": "20260417-093045-123",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "phase": "iteration",
   "iteration": 1,
   "maxIterations": 3,

--- a/docs/code-packages/workflow.md
+++ b/docs/code-packages/workflow.md
@@ -65,21 +65,20 @@ Executes a step inside Docker. `captureMode` is not applicable here — claude s
 
 ```go
 type StepExecutor interface {
-    ui.StepRunner
+    ui.StepRunner   // RunStep, WasTerminated, WasTimedOut, ClearTimeoutFlag, WriteToLog
     LastCapture() string
     LastStats() claudestream.StepStats
     ProjectDir() string
     RunSandboxedStep(stepName string, command []string, opts SandboxOptions) error
     RunStepFull(stepName string, command []string, captureMode ui.CaptureMode, timeoutSeconds int) error
     SessionBlacklisted(id string) bool
-    WasTimedOut() bool
     WriteRunSummary(line string)
 }
 ```
 
-`ui.StepRunner` contributes `RunStep`, `WasTerminated`, and `WriteToLog`.
+`WasTimedOut` and `ClearTimeoutFlag` are inherited from `ui.StepRunner` (the ui layer needs both to route on the soft-timeout policy).
 
-`WasTimedOut()` returns `true` if the most recent step was ended by the per-step timeout goroutine. The flag is reset at the start of each `RunStepFull` or `RunSandboxedStep` call.
+`WasTimedOut()` returns `true` if the most recent step was ended by the per-step timeout goroutine. The flag is reset at the start of each `RunStepFull` or `RunSandboxedStep` call, AND is explicitly cleared by `ClearTimeoutFlag()` when the ui layer's soft-timeout branch (`onTimeout: "continue"`) consumes the signal. The explicit clear is required because the stepDispatcher's WARN-001 pre-check reads the flag BEFORE entering the next `RunStepFull`/`RunSandboxedStep` — without the clear, a stale `true` would fire `onTimeoutRetry` and emit a spurious iteration record for the next step.
 
 ### Session blacklist
 

--- a/docs/coding-standards/versioning.md
+++ b/docs/coding-standards/versioning.md
@@ -31,7 +31,7 @@ When you are about to make a change, ask: "does this break one of the four items
 
 ## `0.y.z` — initial development
 
-The current release is `0.7.0`. Per semver §4, while MAJOR is `0`, **anything may change at any time** and the public API is not considered stable. For this repo, that means:
+The current release is `0.7.1`. Per semver §4, while MAJOR is `0`, **anything may change at any time** and the public API is not considered stable. For this repo, that means:
 
 - Backwards-incompatible changes to the CLI surface or `config.json` schema during `0.y.z` bump the **MINOR** (e.g. `0.6.0` → `0.7.0`), not the major.
 - Backwards-compatible additions and bug fixes both bump the **PATCH** (e.g. `0.6.0` → `0.6.1`).

--- a/docs/features/status-line.md
+++ b/docs/features/status-line.md
@@ -68,7 +68,7 @@ The script receives a single JSON object on stdin:
 ```json
 {
   "sessionId": "20260417-093045-123",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "phase": "iteration",
   "iteration": 1,
   "maxIterations": 3,

--- a/docs/features/tui-display.md
+++ b/docs/features/tui-display.md
@@ -60,7 +60,7 @@ Key files:
   │  │ [log panel — bubbles/viewport]            │ ││  ← scrollable log viewport (white text)
   │  │├───────────────────────────────────────── ┤ ││  ← HRule (T-junctions)
   │  │ ↑/k up  ↓/j down  n next  q quit          │ ││  ← shortcut footer (ShortcutLine)
-  │  │                     pr9k v0.7.0      │ ││  ← version label (right-aligned, white)
+  │  │                     pr9k v0.7.1      │ ││  ← version label (right-aligned, white)
   │  │╰─────────────────────────────────────────╯  ││  ← bottom border
   │  └──────────────────────────────────────────────┘│
   └──────────────────────────────────────────────────┘

--- a/docs/features/tui-display.md
+++ b/docs/features/tui-display.md
@@ -12,7 +12,7 @@ Manages the visual status display for the pr9k terminal interface, showing itera
 - The iteration line is embedded into the top-border title (not rendered as a separate inner row); it shows `Iteration N/M` in bounded mode and `Iteration N` (no total) when total is 0 (unbounded mode)
 - When no stream-json event arrives for ≥15s during an active claude step, the title is suffixed with `  ⋯ thinking (Ns)` — a passive heartbeat indicator (D23) that replaces the "feels alive" contribution of token-level streaming without requiring `--include-partial-messages`. The suffix is pure view state: it updates in-place each second and is never appended to the log ring buffer
 - Displays step progress as a dynamic grid of rows (4 checkboxes per row), sized at startup to fit the largest phase
-- Each step shows one of five states: `[ ]` pending, `[▸]` active, `[✓]` done, `[✗]` failed, `[-]` skipped; the active step marker (`▸`) is rendered in green; all other chrome is light gray
+- Each step shows one of six states: `[ ]` pending, `[▸]` active, `[✓]` done, `[✗]` failed, `[-]` skipped, `[!]` timed-out-continuing (step hit its `timeoutSeconds` and its `onTimeout: "continue"` policy advanced the workflow without prompting); the active step marker (`▸`) is rendered in green; all other chrome is light gray
 - Switches between phases (initialize, iteration, finalize) by sending `headerPhaseStepsMsg` through `headerProxy`
 - The log body is structured with phase banners, iteration separators, per-step "Starting step" banners, variable capture logs, and a final completion summary — all spaced with blank lines (helpers in `log.go`)
 - Terminal width for full-width phase banner underlines is detected via `ui.TerminalWidth()` (ioctl TIOCGWINSZ) with an 80-column fallback
@@ -103,6 +103,7 @@ const (
     StepDone                       // [✓]
     StepFailed                     // [✗]
     StepSkipped                    // [-]
+    StepTimedOutContinuing         // [!] — onTimeout="continue" soft-fail
 )
 
 // HeaderCols is the number of checkbox columns per row; constant to fit 80-column terminals.

--- a/docs/features/workflow-orchestration.md
+++ b/docs/features/workflow-orchestration.md
@@ -411,7 +411,7 @@ func Orchestrate(steps []ResolvedStep, runner StepRunner, header StepHeader, h *
 
 The banner is written **after** the pre-step quit drain so pending quits don't write a banner for a step that will not run. Retries re-enter `runStepWithErrorHandling` and write `RetryStepSeparator(step.Name)` via `WriteToLog` before the retry; the `Starting step` banner is written once per step (not per attempt).
 
-On step failure (non-zero exit, not user-terminated), `runStepWithErrorHandling` enters error mode and blocks on user input:
+On step failure (non-zero exit, not user-terminated), `runStepWithErrorHandling` first consults the per-step `OnTimeout` policy; if the failure was a timeout AND the step is configured `OnTimeout: "continue"`, the step soft-fails (log banner, clear the executor's timeout flag, mark the checkbox `[!]`) and the workflow advances without prompting. Otherwise it enters error mode and blocks on user input:
 
 ```go
 func runStepWithErrorHandling(...) StepAction {
@@ -420,6 +420,14 @@ func runStepWithErrorHandling(...) StepAction {
 
         if err == nil || runner.WasTerminated() {
             header.SetStepState(idx, StepDone)
+            return ActionContinue
+        }
+
+        // Soft-fail on timeout when the step's policy is "continue".
+        if runner.WasTimedOut() && step.OnTimeout == "continue" {
+            runner.WriteToLog(TimeoutContinueBanner(step.Name, step.TimeoutSeconds))
+            runner.ClearTimeoutFlag()  // prevent stale flag leaking to next step's dispatcher
+            header.SetStepState(idx, StepTimedOutContinuing)  // [!]
             return ActionContinue
         }
 
@@ -437,6 +445,8 @@ func runStepWithErrorHandling(...) StepAction {
     }
 }
 ```
+
+`ClearTimeoutFlag` is critical here: the stepDispatcher's WARN-001 pre-check (`run.go:138-144`) fires `onTimeoutRetry` at the start of any `RunStep` call when `WasTimedOut()` is true. Without the clear, the next step's dispatcher would emit a spurious synthetic iteration record (`status=failed, notes="timed out after 0s"`) for a step that never timed out. The iteration record for the soft-failed step itself still carries the truthful `status=failed` + `notes="timed out after Ns"` because `stepStatus(StepTimedOutContinuing) == "failed"` and `setTimeoutNote` checks `lastState == StepTimedOutContinuing` as a secondary signal (the primary flag is cleared by that point).
 
 ### runStats
 

--- a/docs/how-to/configuring-a-status-line.md
+++ b/docs/how-to/configuring-a-status-line.md
@@ -4,7 +4,7 @@ pr9k can display live workflow state in the TUI footer by running a custom scrip
 
 ## Prerequisites
 
-- pr9k 0.7.0 or later
+- pr9k 0.7.1 or later
 - A `config.json` in your workflow directory
 - [`jq`](https://jqlang.github.io/jq/) — required by the sample script to parse stdin JSON
 - `git` (optional) — used by the sample script to display the current branch
@@ -87,7 +87,7 @@ Available fields from stdin:
 | `.step.num` | `4` |
 | `.mode` | `"normal"` |
 | `.captures.ISSUE_ID` | `"42"` |
-| `.version` | `"0.7.0"` |
+| `.version` | `"0.7.1"` |
 | `.workflowDir` | `"/home/user/.local/bin"` |
 | `.projectDir` | `"/home/user/myrepo"` |
 

--- a/docs/how-to/reading-the-tui.md
+++ b/docs/how-to/reading-the-tui.md
@@ -37,7 +37,7 @@ State updates from the orchestration goroutine are sent as typed messages via `H
 
 The topmost region. Step progress for the *current phase*, laid out as rows of 4 checkboxes each. The grid is sized at startup to fit whichever phase has the most steps. When the workflow enters a new phase, `SetPhaseSteps` swaps the step names into the same slots and trailing slots clear to empty.
 
-The five possible states:
+The six possible states:
 
 | Marker | Name | Meaning |
 |--------|------|---------|
@@ -46,6 +46,7 @@ The five possible states:
 | `[✓] <name>` | Done | Completed successfully, or user-terminated with `n` (treated as a skip) |
 | `[✗] <name>` | Failed | Returned non-zero exit and the user chose `c` to continue past it |
 | `[-] <name>` | Skipped | Marked skipped because an earlier step with `breakLoopIfEmpty` exited the iteration |
+| `[!] <name>` | Timed-out, continuing | Hit its `timeoutSeconds` cap AND its `onTimeout: "continue"` policy told pr9k to advance without prompting. Distinct from `[✗]` so you can tell an unattended soft-timeout from a hard failure at a glance. |
 
 **Note:** The initialize phase does not update the checkbox grid — it uses a `noopHeader` during `Orchestrate` so initialize step state isn't rendered. Only the iteration line changes during init. Checkbox rendering resumes at the start of the iteration phase.
 

--- a/docs/how-to/reading-the-tui.md
+++ b/docs/how-to/reading-the-tui.md
@@ -25,7 +25,7 @@ The screen is assembled row-by-row in `Model.View()` inside a hand-built rounded
 │ [test-writing subprocess output streams here]       │
 │                                                     │
 ├─────────────────────────────────────────────────────┤  ← HRule (T-junctions)
-│ ↑/k up  ↓/j down  n next step  q quit  pr9k v0.7.0 │  ← shortcut footer + version
+│ ↑/k up  ↓/j down  n next step  q quit  pr9k v0.7.1 │  ← shortcut footer + version
 ╰─────────────────────────────────────────────────────╯
 ```
 
@@ -186,7 +186,7 @@ The footer uses a two-tone color scheme: the version label on the right renders 
 When a `statusLine` command is configured in `config.json` and its runner has produced output, the footer in Normal mode switches from the standard shortcut bar to a **status-line display**:
 
 ```
-[status text…]                    ? Help | pr9k v0.7.0
+[status text…]                    ? Help | pr9k v0.7.1
 ```
 
 The status text sits on the left and the `? Help | <version>` cluster is right-aligned, so the help hint and version label stay pinned to the right edge regardless of how wide the status text grows or shrinks between refreshes. The status text is the sanitized first non-empty line of the most recent command run; it is right-truncated to protect the `? Help | <version>` cluster. On very narrow terminals the version label may be truncated first; the `? Help` hint is always preserved. During cold-start (before the first successful run), the footer falls back to the standard shortcut bar.

--- a/docs/how-to/recovering-from-step-failures.md
+++ b/docs/how-to/recovering-from-step-failures.md
@@ -108,6 +108,16 @@ In practice this only happens when the config references a missing prompt file. 
 
 Every step is independent. Choosing `c` on iteration 3's "Test writing" doesn't affect iteration 3's "Git push" or iteration 4's "Feature work" — both are still capable of failing and dropping you back into error mode.
 
+### The step timed out but was configured with `onTimeout: "continue"`
+
+If a step's config sets `onTimeout: "continue"` AND the per-step `timeoutSeconds` cap fires, pr9k skips the error-mode pause entirely. You'll see:
+
+1. A one-line banner in the log: `── <step name> timed out after Ns — continuing (onTimeout=continue) ─────────────`
+2. The step's checkbox flips to `[!]` (not `[✗]`) so soft-timeouts are visually distinct from hard failures
+3. The workflow advances to the next step without prompting
+
+The iteration log still records `status: "failed"` with `notes: "timed out after Ns"` for the affected step, so after-the-fact debugging sees the timeout. The bundled "Test writing" step ships with this policy enabled; see [Setting Step Timeouts](setting-step-timeouts.md) for details.
+
 ## Deciding: continue, retry, or quit?
 
 A rough decision tree:

--- a/docs/how-to/setting-step-timeouts.md
+++ b/docs/how-to/setting-step-timeouts.md
@@ -21,11 +21,12 @@ Add `timeoutSeconds` to any step in `config.json`:
   "isClaude": true,
   "model": "sonnet",
   "promptFile": "test-writing.md",
-  "timeoutSeconds": 900
+  "timeoutSeconds": 1800,
+  "onTimeout": "continue"
 }
 ```
 
-`900` seconds (15 minutes) is the default applied to the bundled "Test writing" step — roughly 3× the observed median duration.
+`1800` seconds (30 minutes) is the default applied to the bundled "Test writing" step, sized ~2.5× the observed organic p95 (~733s) with margin for occasional long runs.
 
 **Validator constraint:** `timeoutSeconds` must be a positive integer when set and must not exceed `86400` (24 hours). Omitting the field (or setting it to `0` via omitempty round-trip) means no timeout.
 
@@ -36,7 +37,22 @@ Add `timeoutSeconds` to any step in `config.json`:
    - **Non-claude steps** — delivered via `syscall.Kill(-pid, SIGTERM)` to the process group (the host child is started with `Setpgid: true`, so grandchildren are included).
 2. If the process has not exited within 10 seconds, `SIGKILL` is sent to the same target.
 3. The step's exit code is non-zero → the step is recorded as `status: "failed"` in `.pr9k/iteration.jsonl` with `notes: "timed out after Ns"`.
-4. The workflow enters error mode (same as any other non-zero exit), and the user can choose to continue, retry, or quit.
+4. Next step depends on the `onTimeout` policy (see the next section).
+
+## Soft-fail on timeout — `onTimeout: "continue"`
+
+Per-step `onTimeout` selects what happens when a timeout fires:
+
+- `""` or `"fail"` (default) — the workflow enters error mode and blocks on `c / r / q` input, exactly like any other non-zero exit. Use when a timeout on this step indicates a real problem that a human should see.
+- `"continue"` — pr9k writes a one-line banner to the log ("timed out after Ns — continuing (onTimeout=continue)"), marks the step with the distinct `[!]` checkbox glyph (`StepTimedOutContinuing`), and advances to the next step without prompting. The iteration record still stores `status: "failed"` with the `timed out after Ns` note, so structured logs retain the signal.
+
+`onTimeout: "continue"` is intended for unattended runs where a step's work is typically partial-but-valuable by the time the timer fires (the bundled "Test writing" step is the canonical example: tests and commits may already be in place before the cap). Without this policy, a single overnight timeout would stall the entire run until a human presses `c` or `r`.
+
+Internally, the orchestrate layer calls `ClearTimeoutFlag()` on the runner after taking the continue branch, so the next step's dispatcher sees a clean slate and does not emit a spurious synthetic record.
+
+### Gotcha: interaction with `resumePrevious`
+
+If the step immediately after an `onTimeout: "continue"` step sets `resumePrevious: true`, a soft-timeout path will fall through the G2 gate (`prevState != StepDone`) and the dependent step starts a fresh Claude session instead of resuming. This is validator-warned at config time; add it to the review when combining the two.
 
 ## Partial session-ID blacklist
 
@@ -54,4 +70,4 @@ fix them in batch rather than one at a time. Do not exceed 8 minutes of
 wall-clock test execution.
 ```
 
-The 8-minute figure is an advisory model budget — the model is asked to self-regulate to that limit. `timeoutSeconds: 900` (15 minutes) is the separate, enforced wall-clock cap that pr9k applies regardless of model behaviour. These are distinct: the advisory budget may be exceeded by a non-cooperative model, while the `timeoutSeconds` cap is always enforced by the runtime.
+The 8-minute figure is an advisory model budget — the model is asked to self-regulate to that limit. `timeoutSeconds: 1800` (30 minutes) is the separate, enforced wall-clock cap that pr9k applies regardless of model behaviour. These are distinct: the advisory budget may be exceeded by a non-cooperative model, while the `timeoutSeconds` cap is always enforced by the runtime.

--- a/docs/plans/test-writing-timeout-fail-state.md
+++ b/docs/plans/test-writing-timeout-fail-state.md
@@ -1,0 +1,483 @@
+# Investigation: "Test writing" step forces unattended user into error-mode prompt on timeout
+
+The 900s `timeoutSeconds` on the "Test writing" step is routinely exceeded by productive work, and when the timer fires the orchestrator enters a blocking `c / r / q` prompt — which defeats unattended pr9k runs.
+
+## Problem Statement
+
+- **Symptom:** The screenshot shows the "Test writing" step marked `[x]` (failed) with the `c continue  r retry  q quit` shortcut bar visible at the footer. Prior log body shows Claude was mid-work — writing tests, running the suite, fixing a handful of TP-numbered failures (TP-003, TP-006, TP-015, TP-026). The iteration log (`~/dev/gearjot/gearjot-v2-web/.pr9k/iteration.jsonl`) records the exit as `"status":"failed","duration_s":0,"notes":"timed out after 900s"` — the failure is a wall-clock timeout, not a test-runner non-zero exit. The user misread the symptom as "test runner failed"; the real cause is the 900s per-step cap.
+- **Expected behavior:** When pr9k is run unattended (its whole purpose), a per-step timeout on the "Test writing" step should not block waiting on a human. Either the step should be given enough wall-clock budget to finish the documented prompt work, or the timeout should be a soft fail that logs-and-moves-on.
+- **Conditions:** Occurs on the "Test writing" step (the only step in the shipped workflow with a non-zero `timeoutSeconds`). Correlates with large prior-phase token counts (`Feature work` output > ~20k tokens) and/or iterations where `.ralph-cache/` Go-toolchain layout needs fixup. Observed in both `gearjot-v2` and `gearjot-v2-web` repos, across multiple days of runs.
+- **Impact:** Defeats the unattended design of pr9k for every issue where Test writing runs long. The user either sits at the terminal to press `r` / `c`, or comes back to find a hung TUI that made no further progress overnight. A retry from a fresh session also re-burns 15+ minutes of Claude time because `--resume` is blocked by the G2 and G5 resume gates after a timeout.
+
+## Evidence Summary
+
+### E1: `timeoutSeconds` is declared in the step schema
+
+- **Source:** `src/internal/steps/steps.go:41`, `src/internal/validator/validator.go:88`, `:450-456`
+- **Finding:**
+  ```go
+  // steps.go:41
+  TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
+  // validator.go:446-456
+  if step.TimeoutSeconds != nil {
+      if *step.TimeoutSeconds <= 0 {
+          *errs = append(*errs, at("schema", "timeoutSeconds must be a positive integer when set"))
+      } else if *step.TimeoutSeconds > 86400 {
+          *errs = append(*errs, at("schema", "timeoutSeconds must not exceed 86400 (24 hours)"))
+      }
+  }
+  ```
+- **Relevance:** Top of the plumbing chain. No sibling policy field (`onTimeout`, `continueOnError`, etc.) exists today.
+
+### E2: The shipped workflow sets 900s on "Test writing" only
+
+- **Source:** `workflow/config.json:26`, pinned by `src/internal/validator/production_steps_test.go:365-420`
+- **Finding:**
+  ```json
+  { "name": "Test writing", "isClaude": true, "model": "sonnet", "promptFile": "test-writing.md", "timeoutSeconds": 900 },
+  ```
+- **Relevance:** The single timeout in the shipped workflow. The pin test forbids adding timeouts to any other step without an intentional change.
+
+### E3: Test-writing prompt asks for multi-stage work far beyond "run the test suite"
+
+- **Source:** `workflow/prompts/test-writing.md:11-22`
+- **Finding:**
+  ```
+  1. Write all tests specified in test-plan.md
+  2. Run all tests, type checks, linting and formatting tools. Fix any issues.
+  3. Delete test-plan.md
+  4. Commit changes in a single commit.
+  5. Add a comment to github issue {{ISSUE_ID}} with your progress
+  6. Append your progress to progress.txt
+  7. Append all deferred work to deferred.txt
+  ...
+  Budget: write all tests first, then run the suite ONCE. If >5 tests fail, fix them
+  in batch rather than one at a time. Do not exceed 8 minutes of wall-clock test execution.
+  ```
+- **Relevance:** The "8 minutes" budget is for test *execution*, not step wall-clock. Writing N tests, running the suite, fixing failures, committing, commenting on GitHub, updating progress/deferred files routinely consumes 20-60 minutes on top of that.
+
+### E4: `TimeoutSeconds` flows from config through validator → Step → ResolvedStep → stepDispatcher → Runner
+
+- **Source:** `src/internal/workflow/run.go:150`, `:162`, `:770`, `:786`; `src/internal/workflow/workflow.go:306`, `:344`, `:484-555`
+- **Finding:** `buildStep` copies `s.TimeoutSeconds` into `ui.ResolvedStep`; `stepDispatcher.RunStep` forwards it into `RunSandboxedStep`/`RunStepFull`, which pass it to `runCommand`. A goroutine fires after N seconds, sets `r.timeoutFired = true`, and calls the `Terminator` closure that issues SIGTERM (then SIGKILL after 10 s) to the Docker container via cidfile.
+- **Relevance:** Wall-clock expiry kills the subprocess; `cmd.Wait()` returns a non-nil error because the process was signaled. There is no timeout-specific exit path — it looks identical to any other subprocess failure to the caller.
+
+### E5: `runStepWithErrorHandling` treats ANY non-nil error as failure and enters ModeError
+
+- **Source:** `src/internal/ui/orchestrate.go:86-111`
+- **Finding:**
+  ```go
+  func runStepWithErrorHandling(idx int, step ResolvedStep, runner StepRunner, header StepHeader, h *KeyHandler) StepAction {
+      for {
+          err := runner.RunStep(step.Name, step.Command)
+          if err == nil || runner.WasTerminated() {
+              header.SetStepState(idx, StepDone)
+              return ActionContinue
+          }
+          header.SetStepState(idx, StepFailed)
+          h.SetMode(ModeError)
+          action := <-h.Actions  // BLOCKS on user input
+          h.SetMode(ModeNormal)
+          switch action {
+          case ActionContinue:
+              return ActionContinue
+          case ActionRetry:
+              runner.WriteToLog(RetryStepSeparator(step.Name))
+          case ActionQuit:
+              return ActionQuit
+          }
+      }
+  }
+  ```
+- **Relevance:** **This is the single policy site that forces the `c/r/q` prompt.** `WasTimedOut()` is never consulted — a timeout is indistinguishable from any other failure. The blocking receive at `action := <-h.Actions` parks the orchestrator until a human presses a key.
+
+### E6: `ui.StepRunner` does not expose `WasTimedOut`; only `workflow.StepExecutor` does
+
+- **Source:** `src/internal/ui/orchestrate.go:22-26`, `src/internal/workflow/run.go:66-85`
+- **Finding:**
+  ```go
+  // ui.StepRunner
+  type StepRunner interface {
+      RunStep(name string, command []string) error
+      WasTerminated() bool
+      WriteToLog(line string)
+  }
+  // workflow.StepExecutor (superset)
+  type StepExecutor interface {
+      ui.StepRunner
+      ...
+      WasTimedOut() bool
+      ...
+  }
+  ```
+- **Relevance:** The UI layer today cannot distinguish a timeout from any other failure. Any fix that routes on timeout must extend `ui.StepRunner`.
+
+### E7: `WasTimedOut` is consulted only for log annotation, never for routing
+
+- **Source:** `src/internal/workflow/run.go:236-243`
+- **Finding:**
+  ```go
+  func setTimeoutNote(rec *IterationRecord, executor StepExecutor, s steps.Step) {
+      if executor.WasTimedOut() && s.TimeoutSeconds > 0 {
+          rec.Notes = fmt.Sprintf("timed out after %ds", s.TimeoutSeconds)
+      }
+  }
+  ```
+- **Relevance:** Confirms the `"notes":"timed out after 900s"` string in the user's iteration.jsonl. No control-flow branch depends on it.
+
+### E8: No existing config knob for soft-fail / continue-on-error / auto-retry
+
+- **Source:** Full-repo search for `continueOnError|allowFailure|nonFatal|onTimeout|onError|skipOnError|softFail|bestEffort` (production code only). Zero matches.
+- **Relevance:** A new schema field is required to express "treat timeout as non-fatal" without changing the default behavior of every other step.
+
+### E9: Retry-after-timeout starts a fresh Claude session (no `--resume`)
+
+- **Source:** `src/internal/workflow/run.go:749-786` (`buildStep` is called once per step per iteration, threads `resumeSessionID` into argv); `src/internal/sandbox/command.go:83-84` (argv bakes `--resume` in); `src/internal/ui/orchestrate.go:105-107` (retry loop reuses the same pre-built `step.Command`)
+- **Finding:** The retry inside `runStepWithErrorHandling` does NOT rebuild the step or re-derive `resumeSessionID`, so a retry cannot inject `--resume <original_sid>`. The G5 gate (`src/internal/workflow/run.go:273-275`) explicitly blacklists timed-out session IDs to prevent resume: `"G5: previous step session is blacklisted (was timed out)"`. G2 would also fail because the timed-out step ends in `StepFailed` not `StepDone`.
+- **Relevance:** A retry loses ~15 minutes of accumulated context. The user's iteration.jsonl shows this — the failed record and the subsequent `"status":"done"` record carry different session IDs.
+
+### E10: Two-record pattern is emitted when the user presses `r`
+
+- **Source:** `src/internal/workflow/run.go:138-144` (`WARN-001` block in `stepDispatcher.RunStep`), `:554-560` (the `onTimeoutRetry` closure); user data at `/Users/mxriverlynn/dev/gearjot/gearjot-v2/.pr9k/iteration.jsonl:75-76`
+- **Finding:**
+  ```json
+  {"step_name":"Test writing","model":"sonnet","status":"failed","duration_s":0,"notes":"timed out after 900s"}
+  {"step_name":"Test writing","model":"sonnet","status":"done","duration_s":4709.91,"session_id":"7bc8ae27-..."}
+  ```
+- **Relevance:** Confirms iter06 was rescued by a 78-minute fresh retry. The `duration_s:0` on the failed record is the signature of the WARN-001 synthetic record; the engine already separates "timed out" from regular failures for accounting — just not for control flow.
+
+### E11: Distribution of "Test writing" duration_s across completed runs — separating organic from retry-after-timeout
+
+- **Source:** `~/dev/gearjot/gearjot-v2-web/.pr9k/iteration.jsonl`, `~/dev/gearjot/gearjot-v2/.pr9k/iteration.jsonl`
+- **Finding:** Full record counts: 11 "done", 3 "failed" (all timeouts), 1 "unknown" (crashed pre-iter). Three of the 11 "done" records are **retry-from-fresh durations** (the Claude session was restarted after a timeout — 1662s, 1841s, 4710s). **Organic first-shot successful durations** (n=8): `237, 236, 390, 403, 518, 592, 642, 734`. Mean ≈ 469s, median ≈ 468s, **p95 ≈ 733s, max 734s**. Retry-after-timeout durations are pathological (a fresh session re-derives all context from scratch) and must not be used to size the cap.
+- **Relevance:** Under the current 900s cap, 3 out of 11 first-shot attempts timed out (27% timeout rate on first attempt). The organic first-shot p95 is 733s — below the current cap — but the right tail pushes past it. Once `onTimeout=continue` is in place, retries disappear as a signal; the organic distribution is what matters. A cap of 1800s (30 min) covers organic p99 with a generous margin; 3600s was originally proposed based on the conflated p95 of 4710s and is more than necessary.
+
+### E12: At the moment of the v2-web iter05 kill, Claude was on the last TodoWrite item with tests passing
+
+- **Source:** Last ~10 events of `~/dev/gearjot/gearjot-v2-web/.pr9k/logs/ralph-2026-04-21-102430.433/iter05-08-test-writing.jsonl` (session_id `5b4c1118-cb4f-4ca9-9a39-151a585b8491`)
+- **Finding:** Final TodoWrite state: `[Fix TP-026 (in_progress), Delete test-plan.md, Run format/lint/check then commit, Comment on GH 156, Append progress/deferred]`. Immediately prior tool_result from `npm run format && npm run lint && npm run check`: `COMPLETED 6241 FILES 0 ERRORS 0 WARNINGS`. Last assistant message: `"All clean. Now run just the failing test file to confirm it passes:"` — then killed.
+- **Relevance:** Claude was productively within 2-3 minutes of completion. The user's intuition that "it shouldn't be a fail state" is correct for this concrete case.
+
+### E13: Timeout blacklist gate (G5) is populated at `RunSandboxedStep` return — before any retry
+
+- **Source:** `src/internal/workflow/workflow.go:352-361`
+- **Finding:**
+  ```go
+  r.processMu.Lock()
+  if r.timeoutFired && stats.SessionID != "" {
+      if r.sessionBlacklist == nil {
+          r.sessionBlacklist = make(map[string]bool)
+      }
+      r.sessionBlacklist[stats.SessionID] = true
+  }
+  r.processMu.Unlock()
+  ```
+- **Relevance:** Even if a future redesign wanted to auto-resume after timeout, G5 would reject it. The blacklist is policy (`"a timed-out session's state is unknown"` — `run.go:258`), not a bug. For a soft-timeout fix we do NOT need to change the blacklist — we only need to stop blocking the user.
+
+### E14: The step itself can flail on environment issues and fill 900s with non-productive work
+
+- **Source:** `~/dev/gearjot/gearjot-v2/.pr9k/logs/ralph-2026-04-21-095746.014/iter05-08-test-writing.jsonl` (734s, finished but barely)
+- **Finding:** A contiguous block of ~15 bash commands dedicated to fixing Go toolchain layout in `.ralph-cache/`: `chmod +x` on `golang.org/toolchain@v0.0.1-go1.26.2.linux-arm64/bin/go`, copying to `/tmp/go1.26.2`, building `/tmp/goroot1262/pkg/tool`, repeated `GOROOT=... GOPATH=... GOMODCACHE=... go test` invocations.
+- **Relevance:** Not every 900s-ish run is "productive work". When `.ralph-cache/` permissions collide with the sandbox UID mapping, Claude can burn real wall-clock on workarounds. A pure "raise the timeout" fix would not distinguish productive work from stuck loops; a "soft-fail on timeout" fix bounds blast radius regardless of the cause.
+
+## Root Cause Analysis
+
+### Summary
+
+The 900s cap on "Test writing" is systematically smaller than the prompt's actual workload (median ≈555s, p95 ≈4710s), and when it fires `runStepWithErrorHandling` forces a blocking `c/r/q` prompt because the orchestrator treats every non-zero subprocess exit identically.
+
+### Detailed Analysis
+
+Two independent defects compound:
+
+1. **Cap mis-sized for workload.** The `timeoutSeconds: 900` on "Test writing" (E2) is below the observed median runtime across 10 successful runs (E11). The prompt asks Claude to write N tests, run the suite, fix failures, commit, comment on GitHub, and update two progress files (E3). Even a clean run routinely exceeds 15 minutes. When Claude is within minutes of completing the documented work (E12), the timer kills it.
+
+2. **Timeout forces human-blocking error mode.** When the timer fires, it SIGTERMs the subprocess via the cidfile Terminator (E4). `cmd.Wait()` returns a non-nil error. `runStepWithErrorHandling` (E5) checks only `err != nil` and `runner.WasTerminated()` (user-initiated skip), enters `ModeError`, and blocks on `<-h.Actions`. `WasTimedOut()` is consulted only for log annotation (E7), never for routing. The `ui.StepRunner` interface does not even expose `WasTimedOut` — only `workflow.StepExecutor` does (E6). Consequently a timeout and a genuine step failure are indistinguishable to the UI layer, and an unattended run becomes a stalled TUI.
+
+On retry, the original session cannot be resumed because `buildStep` is called only once per step and the G5 gate blacklists timed-out session IDs anyway (E9, E13), so 15+ minutes of accumulated context is thrown away. The resulting two-record pattern in `iteration.jsonl` (E10) reflects this: a synthetic `duration_s:0 notes:"timed out..."` record, followed by a fresh-session `done` record at the full retry duration.
+
+The user's phrasing pointed at "the test runner failing" — but the test runner's non-zero exits are handled inline by Claude within the step (retry/batch-fix, per the prompt's budget line). The actual fail-state is always and only the wall-clock timeout.
+
+## Coding Standards Reference
+
+| Standard | Source | Applies To |
+|----------|--------|------------|
+| Config schema additions are backwards-compatible additions to the public API; omit field → existing behavior preserved. `0.y.z` treats backward-compatible additions as PATCH bumps. | `docs/coding-standards/versioning.md:15-38` | New `onTimeout` field on `steps.Step`, validator, pin tests |
+| Validate preconditions at function boundary with a clear error. | `docs/coding-standards/api-design.md:30-41` | Validator rule for `onTimeout` enum values |
+| Document unused parameters; no silent drift between `ui.StepRunner` and `workflow.StepExecutor`. | `docs/coding-standards/api-design.md:3-15`, `:108-126` | Extending `ui.StepRunner` with `WasTimedOut` |
+| Race-detector-required tests; closeable idempotency; input immutability. | `docs/coding-standards/testing.md` | New orchestrate + validator tests |
+| Error messages package-prefixed (`steps:`, `workflow:`, etc.) | `docs/coding-standards/error-handling.md` | New validator error message |
+| Narrow-reading principle: workflow content (policy defaults for specific steps) lives in `config.json`, not Go. | `docs/adr/20260410170952-narrow-reading-principle.md` | Decision to put `onTimeout: "continue"` in `workflow/config.json`, not hard-code it |
+| Lint suppressions prohibited. | `docs/coding-standards/lint-and-tooling.md` | New code must pass `make ci` without exclusions |
+
+## Planned Fix
+
+### Summary
+
+Add a new optional per-step `onTimeout` policy field (`"fail" | "continue"`, default `"fail"`), teach `runStepWithErrorHandling` to consult it so a timeout with `"continue"` records the step as failed-but-proceeding (new `StepTimedOutContinuing` state with a distinct TUI glyph) and advances without blocking. Explicitly clear the executor's `timeoutFired` flag when the continue branch is taken so the next step's dispatcher does not see stale state. Configure `"Test writing"` with `onTimeout: "continue"` and raise its `timeoutSeconds` to **1800** (30 min) — 2.5× organic p95 (E11), which absorbs legitimate long runs while keeping a ceiling for pathological hangs. Bump the version to 0.7.1.
+
+The two sub-changes together resolve both compounding defects: the larger cap absorbs legitimate long runs, and the `onTimeout: "continue"` policy ensures the rare remaining genuine runaways log-and-move-on instead of parking the TUI overnight.
+
+### Changes
+
+#### `src/internal/steps/steps.go`
+
+- **Change:** Add `OnTimeout string \`json:"onTimeout,omitempty"\`` to `Step`. Document accepted values (`""` == `"fail"` == current behavior; `"continue"` == treat timeout as non-fatal).
+- **Evidence:** (E1), (E5), (E8)
+- **Standards:** versioning (additive), api-design (document default)
+- **Details:** Field doc comment explicitly states that `""` preserves existing behavior so every pre-existing `config.json` is unaffected.
+
+#### `src/internal/validator/validator.go`
+
+- **Change:** Add `vStep.OnTimeout` field. In the Schema 2d block (right after `timeoutSeconds` rules), validate: if set, must be one of `"fail"`, `"continue"`. If `onTimeout` is set without `timeoutSeconds > 0`, emit a non-fatal warning (mirrors how `skipIfCaptureEmpty` relates to `captureAs`).
+- **Evidence:** (E1), (E8)
+- **Standards:** api-design (precondition at boundary), error-handling (package-prefixed messages)
+- **Details:** Reject `"retry"` and other values for now — scope-minimal. Future expansion (auto-retry) can add values without breaking callers that use `"fail"` or `"continue"`.
+
+#### `src/internal/ui/orchestrate.go`
+
+- **Change:** Extend `StepRunner` with `WasTimedOut() bool` AND `ClearTimeoutFlag()`. Add `OnTimeout string` to `ResolvedStep`. Add a new `StepState` value `StepTimedOutContinuing` (with its own glyph — see `StepState` block change below). In `runStepWithErrorHandling`, after the existing `err == nil || WasTerminated()` branch, add a new branch: if `runner.WasTimedOut() && step.OnTimeout == "continue"`, write a one-line banner, call `runner.ClearTimeoutFlag()`, mark the step `StepTimedOutContinuing`, and return `ActionContinue` without entering `ModeError`.
+- **Evidence:** (E5), (E6), (E7); addresses V4/V13 (residual flag), V7 (checkbox semantics)
+- **Standards:** api-design (narrow interface — add only the two methods we consume; `ClearTimeoutFlag` name is explicit about its effect), concurrency (`WasTimedOut` and `ClearTimeoutFlag` are already mutex-protected in `workflow.Runner`)
+- **Details:**
+  ```go
+  // orchestrate.go (new branch inside runStepWithErrorHandling)
+  if err == nil || runner.WasTerminated() {
+      header.SetStepState(idx, StepDone)
+      return ActionContinue
+  }
+  if runner.WasTimedOut() && step.OnTimeout == "continue" {
+      runner.WriteToLog(TimeoutContinueBanner(step.Name, step.TimeoutSeconds))
+      runner.ClearTimeoutFlag()  // V4 fix: prevent next step's dispatcher from firing WARN-001
+      header.SetStepState(idx, StepTimedOutContinuing)
+      return ActionContinue
+  }
+  header.SetStepState(idx, StepFailed)
+  h.SetMode(ModeError)
+  ...
+  ```
+  Banner copy mirrors the `"timed out after %ds"` string already in iteration.jsonl (E7).
+- **Also update `StepRunner` interface:**
+  ```go
+  type StepRunner interface {
+      RunStep(name string, command []string) error
+      WasTerminated() bool
+      WasTimedOut() bool          // NEW — delegated by stepDispatcher to the executor
+      ClearTimeoutFlag()          // NEW — idempotent reset of executor.timeoutFired
+      WriteToLog(line string)
+  }
+  ```
+
+#### `src/internal/ui/ui.go` (or wherever `StepState` lives)
+
+- **Change:** Add `StepTimedOutContinuing StepState` alongside existing states. Map it to a distinct checkbox glyph (recommend `[!]`) so the user can visually distinguish "step was soft-timed out, workflow continued" from "step hard-failed, user pressed continue". Update `stepStatus` mapping in `src/internal/workflow/run.go:220-234` to return `"failed"` for `StepTimedOutContinuing` so iteration.jsonl still records the timeout truthfully (with the `setTimeoutNote` attaching `"timed out after Ns"`).
+- **Evidence:** (V7 validation finding)
+- **Standards:** TUI chrome is explicitly NOT public API (versioning.md item 3), so adding a glyph is not a breaking change.
+- **Details:** Update `tui-display.md` state table and the two how-to guides that reference checkbox meanings (`docs/how-to/reading-the-tui.md`, `docs/how-to/recovering-from-step-failures.md`).
+
+#### `src/internal/workflow/workflow.go`
+
+- **Change:** Add `ClearTimeoutFlag()` method on `*Runner`:
+  ```go
+  // ClearTimeoutFlag resets the timed-out flag. Called from the ui layer when a
+  // soft-fail-on-timeout policy has consumed the flag and the workflow is advancing
+  // to the next step. Must be called before the next step's dispatcher consults
+  // WasTimedOut(), otherwise a stale true will trigger a spurious WARN-001 record.
+  func (r *Runner) ClearTimeoutFlag() {
+      r.processMu.Lock()
+      defer r.processMu.Unlock()
+      r.timeoutFired = false
+  }
+  ```
+- **Evidence:** (V4)
+- **Standards:** concurrency (mutex-protected write, matches existing pattern at `workflow.go:195-210`)
+
+#### `src/internal/workflow/run.go`
+
+- **Change:** Three additions:
+  1. In `buildStep`, copy `s.OnTimeout` into `ui.ResolvedStep.OnTimeout` in both the claude and non-claude branches (around lines 770, 786).
+  2. Add `WasTimedOut()` and `ClearTimeoutFlag()` delegations on `stepDispatcher` (it already wraps the executor; add two 1-line pass-throughs alongside the existing `WasTerminated` delegation at `:165`):
+     ```go
+     func (d *stepDispatcher) WasTimedOut() bool    { return d.exec.WasTimedOut() }
+     func (d *stepDispatcher) ClearTimeoutFlag()    { d.exec.ClearTimeoutFlag() }
+     ```
+  3. Update `stepStatus` to map `StepTimedOutContinuing` → `"failed"` so iteration.jsonl records the timeout truthfully.
+- **Evidence:** (E4), (V3), (V12)
+- **Standards:** api-design (consistent field threading across both buildStep branches; dispatcher delegation matches existing pattern at `:165-166`)
+
+#### `src/internal/workflow/workflow_test.go` and `src/internal/workflow/run_timeout_test.go`
+
+- **Change:** Add tests for `Runner.ClearTimeoutFlag()` (idempotent, resets flag). Add a cross-step integration test that executes step A (claude, with `TimeoutSeconds=1, OnTimeout="continue"`, deliberate sleep to trigger timeout) followed by step B (non-claude, success). Assert iteration.jsonl contains exactly:
+  - One record for step A: `status="failed", notes="timed out after 1s"`.
+  - One record for step B: `status="done"`, and NO spurious WARN-001 record with `timed out after 0s`.
+- **Evidence:** (V4), (V13)
+- **Standards:** testing (race detector required — new test must run under `go test -race`)
+
+#### `workflow/config.json`
+
+- **Change:** On the `"Test writing"` step, change `"timeoutSeconds": 900` → `"timeoutSeconds": 1800` and add `"onTimeout": "continue"`.
+- **Evidence:** (E2), (E3), (E11), (E12), (E14); addresses V1 (retry-vs-organic distribution correction)
+- **Standards:** narrow-reading ADR (step policy belongs in config.json, not Go), versioning (new schema field addition + workflow content update)
+- **Details:** 1800s (30 min) is ~2.5× organic p95 (733s per revised E11). This absorbs the observed first-shot tail with generous margin while keeping a meaningful ceiling against pathological hangs. With `onTimeout: "continue"`, the rare run that exceeds 1800s is logged-and-proceeded (not retried), so a tighter cap no longer risks losing work to retry pathology.
+
+#### `src/internal/validator/production_steps_test.go`
+
+- **Change:** Update `TestLoadSteps_TestWritingStep_TimeoutSeconds` (line 361-ff) to assert `TimeoutSeconds == 1800` and `OnTimeout == "continue"`. Keep `TestLoadSteps_OnlyTestWritingHasTimeout` unchanged (Test writing is still the only step with a timeout).
+- **Evidence:** (E2)
+- **Standards:** testing (pin tests lock shipped config intent)
+
+#### `src/internal/ui/orchestrate_test.go`
+
+- **Change:** Update the `stubRunner` and `callbackStubRunner` test doubles (src/internal/ui/orchestrate_test.go:13-44) to implement the two new interface methods (`WasTimedOut() bool`, `ClearTimeoutFlag()`). Add test cases covering:
+  - Timeout with `OnTimeout="continue"` marks step state `StepTimedOutContinuing`, calls `ClearTimeoutFlag`, and returns `ActionContinue` without reading from `h.Actions` (no blocking).
+  - Timeout with `OnTimeout=""` (default) still enters `ModeError` exactly as today.
+  - Timeout with `OnTimeout="fail"` (explicit) behaves identically to the default.
+  - Non-timeout failure (`WasTimedOut=false`) with `OnTimeout="continue"` still enters `ModeError` — the policy is timeout-specific, not generic soft-fail.
+- **Evidence:** (V3) — enumerates specific test doubles
+- **Standards:** testing (race detector required)
+
+#### `src/internal/validator/validator.go`
+
+- **Change:** Add a non-fatal warning when `onTimeout: "continue"` is set on a step that is immediately followed by a step with `resumePrevious: true`. Text: `"onTimeout:continue on step X means the following resumePrevious:true step Y will fall through G2 on timeout paths (fresh session)"`.
+- **Evidence:** (V5)
+- **Standards:** validator (non-fatal info/warning severity already exists)
+
+#### `src/internal/version/version.go`
+
+- **Change:** `const Version = "0.7.0"` → `const Version = "0.7.1"`.
+- **Evidence:** (V10) — versioning.md §"0.y.z" classifies backwards-compatible schema additions as PATCH bumps.
+- **Standards:** versioning.md §"How to bump the version" — separate commit, combined with docs-only changes is allowed.
+
+#### `docs/how-to/setting-step-timeouts.md`
+
+- **Change:** Add a section "Soft-fail on timeout" documenting `onTimeout: "continue"`, linking the use case to unattended runs. Cross-link to the `resumePrevious` interaction (V5): "if a step immediately after a `onTimeout:continue` step uses `resumePrevious:true`, a soft timeout causes the resume to fall through G2 and start a fresh session."
+- **Evidence:** (E3), (E11), (E12), (V5)
+- **Standards:** documentation.md (feature docs ship with feature)
+
+#### `docs/features/tui-display.md`, `docs/how-to/reading-the-tui.md`, `docs/how-to/recovering-from-step-failures.md`
+
+- **Change:** Document the new `StepTimedOutContinuing` checkbox glyph (`[!]` or chosen symbol) and its meaning: the step was soft-timed-out and the workflow advanced. Distinct from `[x]` (hard failure, user consulted via ModeError).
+- **Evidence:** (V7)
+- **Standards:** documentation.md
+
+#### `docs/code-packages/workflow.md`, `docs/features/workflow-orchestration.md`, `CLAUDE.md`
+
+- **Change:** Update the `runStepWithErrorHandling` description and the G-gate / resume discussion to note the new `onTimeout` branch and `ClearTimeoutFlag` call. Add a one-line entry in the CLAUDE.md index for the new how-to section if documentation.md requires it.
+- **Evidence:** project instructions require CLAUDE.md to list new docs
+- **Standards:** documentation.md
+
+## Validation Results
+
+### Counter-Evidence Investigated
+
+#### V1: E11 distribution conflates retry-after-timeout durations with organic runtime
+
+- **Hypothesis:** "10 successes / 3 timeouts, p95 ≈ 4710s" is an accurate sizing signal for the 3600s choice.
+- **Investigation:** Re-counted both iteration.jsonl files. Actual: 11 successes + 3 timeouts + 1 "unknown" (crashed). Three of the 11 "done" records (1662s, 1841s, 4710s) are retry-from-fresh durations after a prior timeout, NOT first-shot completion times. Organic first-shot distribution: n=8, values `237, 236, 390, 403, 518, 592, 642, 734`, p95 ≈ 733s.
+- **Result:** Partially Refuted.
+- **Impact:** Plan now sizes the cap against **organic** first-shot p95, not retry-tail p95. Chose **1800s** (~2.5× organic p95 — 733×2.5 = 1832) instead of 3600s. E11 text rewritten to separate organic from retry durations.
+
+#### V2: Is `runStepWithErrorHandling` truly the only ModeError transition?
+
+- **Hypothesis:** Some other site also transitions into ModeError on step failure, making the fix incomplete.
+- **Investigation:** Grepped all `ModeError` mentions in `src/`. All non-test production references are **reads** (switch arms on current mode at `keys.go:30`, `ui.go:19/:125/:209`, `wiring.go:21`, `model.go:255`), not writes. Only `orchestrate.go:96` transitions INTO ModeError in production.
+- **Result:** Confirmed.
+- **Impact:** No additional fix-sites required.
+
+#### V3: Which concrete types implement `StepRunner` and will break on interface extension?
+
+- **Hypothesis:** Extending `ui.StepRunner` with `WasTimedOut` breaks existing test doubles.
+- **Investigation:** Enumerated: `*workflow.Runner` (already implements both), `*workflow.stepDispatcher` (needs 1-line delegations), `*ui.stubRunner` at `orchestrate_test.go:13-30` (needs updates), `*ui.callbackStubRunner` at `orchestrate_test.go:34-44` (needs updates). Plan originally said only "test doubles for StepRunner" — too vague.
+- **Result:** Partially Refuted.
+- **Impact:** Plan's Changes section now explicitly enumerates `stepDispatcher.WasTimedOut()` delegation AND both test-double updates.
+
+#### V4: Residual `WasTimedOut` flag persists across dispatcher boundaries — BLOCKING DEFECT
+
+- **Hypothesis:** After the orchestrate-layer continue branch, the flag `r.timeoutFired` remains true until the next step's `RunStepFull` / `RunSandboxedStep` resets it on entry. BUT the next step's `stepDispatcher.RunStep` checks `d.exec.WasTimedOut()` BEFORE calling the inner executor (at `run.go:138-144`). That check fires `onTimeoutRetry`, which emits a spurious `{"step":"NextStep","status":"failed","notes":"timed out after 0s"}` record in iteration.jsonl.
+- **Investigation:** Read `run.go:138-144`, `workflow.go:263-265`, `workflow.go:291-294`. Confirmed: `r.timeoutFired` is reset only at executor entry, never at orchestrate-layer exit. The dispatcher's WARN-001 guard at `run.go:142-143` fires on any true value regardless of whether the dispatcher's own step has a timeout.
+- **Result:** Refuted (fix-induced defect).
+- **Impact:** Plan now adds `ClearTimeoutFlag()` method on `workflow.Runner` and `stepDispatcher`, exposed via `ui.StepRunner`. Orchestrate calls it inside the continue branch before returning. New cross-step integration test asserts iteration.jsonl contains no spurious record on the following step.
+
+#### V5: `onTimeout:continue` interaction with downstream `resumePrevious:true`
+
+- **Hypothesis:** A downstream step with `resumePrevious:true` would silently lose resume after a soft-timeout because G2 requires `prevState == StepDone`.
+- **Investigation:** Confirmed G2 check at `run.go:267-269`. Shipped `workflow/config.json` has no `resumePrevious:true` anywhere, so no immediate blast radius. But future users combining the two would be surprised.
+- **Result:** Confirmed (no immediate impact, but a documented gotcha).
+- **Impact:** Plan adds a validator non-fatal warning when `onTimeout:"continue"` precedes a `resumePrevious:true` step, and a cross-link in the how-to doc.
+
+#### V6: `WasTimedOut()` flag lifecycle at the orchestrate-layer check point
+
+- **Hypothesis:** The flag correctly reflects the step that just ran when `runStepWithErrorHandling` checks it after `runner.RunStep` returns.
+- **Investigation:** Traced: entry reset → timer goroutine set under `!r.terminated` guard → `cmd.Wait` returns → orchestrate reads. The existing WARN-003 re-check prevents setting the flag for a successful completion that raced the timer. Lifecycle is correct at the check point.
+- **Result:** Confirmed. The read site is safe; the bug is the downstream persistence (V4).
+- **Impact:** No change to the check itself; the `ClearTimeoutFlag` addition (V4) handles the downstream persistence.
+
+#### V7: Checkbox `[x]` + continuing workflow is visually incoherent
+
+- **Hypothesis:** Showing `[x]` (hard fail) while the TUI advances to the next step contradicts the existing meaning of `[x]` (which pairs with ModeError).
+- **Investigation:** `docs/features/tui-display.md:104` documents `[✗]` as hard fail. Versioning.md confirms TUI chrome is NOT public API, so a new state is cheap. Plan originally picked "keep `[x]`" for simplicity.
+- **Result:** Partially Refuted.
+- **Impact:** Plan now introduces a distinct `StepTimedOutContinuing` state with its own glyph (`[!]` recommended) so operators can visually distinguish soft-timeout from hard-fail. Documentation updated across tui-display.md, reading-the-tui.md, recovering-from-step-failures.md.
+
+#### V8: Race between `WasTerminated` (user skip) and `WasTimedOut` (timer)
+
+- **Hypothesis:** Both flags could become true simultaneously, corrupting the orchestrate branch logic.
+- **Investigation:** Read `workflow.go:195-210` (Terminate) and `:512-516` (timer goroutine). Both mutate under `processMu` with a first-flag-wins guard. WARN-002 invariant is enforced. No race.
+- **Result:** Confirmed.
+- **Impact:** Ordering of orchestrate branches (Terminated first, then TimedOut-with-continue, then default error) is correct as proposed.
+
+#### V9: Version bump missing from plan
+
+- **Hypothesis:** Adding `onTimeout` to the JSON schema requires a version bump.
+- **Investigation:** versioning.md item 2 says config.json schema is public API; §"0.y.z" says backwards-compatible additions bump PATCH.
+- **Result:** Partially Refuted.
+- **Impact:** Plan now includes `src/internal/version/version.go` → `0.7.1` as an explicit change.
+
+#### V10: Simpler alternative — just remove `timeoutSeconds`
+
+- **Hypothesis:** Bare removal of the cap (no policy change) is sufficient.
+- **Investigation:** Without a cap, a truly-hung Claude step would stall indefinitely in an unattended run. No run-level cap exists. Removing the cap trades "blocks on prompt" for "silently hangs forever" — strictly worse for unattended automation.
+- **Result:** Confirmed (alternative is inferior).
+- **Impact:** Plan's policy-plus-raised-cap approach is retained as strictly better.
+
+#### V11: `stepStatus` mapping for the new state
+
+- **Hypothesis:** Mapping `StepTimedOutContinuing` → `"failed"` in iteration.jsonl preserves truthful structured logging.
+- **Investigation:** `stepStatus` at `run.go:220-234` currently maps `StepFailed` → `"failed"`. Extending to map `StepTimedOutContinuing` → `"failed"` means the setTimeoutNote call still attaches `"timed out after Ns"`. Operators grepping for timeouts continue to see today's behavior.
+- **Result:** Confirmed.
+- **Impact:** Plan explicitly specifies this mapping in the run.go change list.
+
+#### V12: Cross-step integration test coverage
+
+- **Hypothesis:** Original plan's test list covered only single-step scenarios and would have missed V4/V13.
+- **Investigation:** Plan's original tests were orchestrate-layer unit tests with a `stubRunner`; none exercised the dispatcher seam where the bug lives.
+- **Result:** Refuted (coverage gap).
+- **Impact:** Plan now requires a cross-step integration test in `workflow/run_timeout_test.go` that exercises step A (claude, forced timeout, `OnTimeout=continue`) followed by step B (non-claude success) and asserts exact iteration.jsonl contents.
+
+### Adjustments Made
+
+- **V1:** Rewrote E11 to separate organic from retry durations; changed proposed `timeoutSeconds` from 3600 → 1800 with rationale tied to organic p95.
+- **V3:** Explicitly enumerated `stepDispatcher.WasTimedOut()` delegation plus both `stubRunner` and `callbackStubRunner` updates.
+- **V4:** Added `ClearTimeoutFlag()` on `workflow.Runner`, `stepDispatcher`, and `ui.StepRunner`. Orchestrate calls it inside the continue branch.
+- **V5:** Added validator non-fatal warning + docs cross-link for `onTimeout:continue` preceding `resumePrevious:true`.
+- **V7:** Introduced `StepTimedOutContinuing` state with its own glyph; updated three TUI-facing docs.
+- **V9:** Added `version.Version` bump to 0.7.1 as an explicit change.
+- **V11:** Specified `stepStatus(StepTimedOutContinuing) = "failed"` mapping.
+- **V12:** Added cross-step integration test to the test list.
+
+### Confidence Assessment
+
+- **Confidence:** Medium-High (raised from Low after adjustments).
+- **Remaining Risks:**
+  1. **Run-summary accuracy on soft-timeout** (validator's untouched area): `stepDispatcher.RunStep` folds `LastStats()` into `runStats` after `RunSandboxedStep` returns, regardless of success. On a soft timeout, partial stats (tokens consumed up to the SIGTERM moment) are counted. Intended behavior, but the run-level summary should be spot-checked to confirm it still sums correctly when `onTimeout=continue` is in play.
+  2. **Organic p95 basis is 8 samples** (E11); 1800s may need to be tuned up once more data accumulates. The policy-layer fix is resilient to mis-sizing — a timeout that fires with `onTimeout:continue` just logs-and-proceeds rather than blocking.
+  3. **Downstream resume interaction (V5)** is a gotcha, not a regression. The validator warning + docs call it out, but an operator who ignores the warning and sets `resumePrevious:true` on a step after Test writing will silently lose resume on soft-timeout paths.
+  4. **New `[!]` glyph semantics** need to be understood by users; the checkbox is no longer a binary done/fail state. Visual review during implementation is recommended.
+
+## Final Summary
+
+- **Root Cause:** `timeoutSeconds: 900` is smaller than the observed first-shot tail of the documented Test-writing prompt (organic p95 ≈ 733s, max 734s, right tail exceeds 900s), and `runStepWithErrorHandling` forces a blocking `c/r/q` prompt on any non-zero subprocess exit (E5) regardless of whether the failure was a timeout, defeating unattended runs.
+- **Fix:** Raise Test writing's `timeoutSeconds` to 1800, add a new optional `onTimeout: "fail" | "continue"` per-step policy that makes a timeout non-fatal (new `StepTimedOutContinuing` state with `[!]` glyph, `ClearTimeoutFlag` called to prevent the dispatcher's WARN-001 from firing on the next step, iteration.jsonl still records `status=failed` with the `timed out after Ns` note), configure `"Test writing"` with `onTimeout: "continue"`, and bump version to 0.7.1.
+- **Why Correct:** E5 + E6 establish the single policy site; E7 + E10 show the existing WARN-001 accounting already separates timeouts from failures at the flag level and can be routed on; E11 (revised) sizes the cap to organic tail; V4 closes the only blocking fix-induced defect; V7 resolves the visual-coherence concern.
+- **Validation Outcome:** Refuted one blocking defect (V4) and corrected the distribution analysis (V1) that had inflated the proposed cap; plan updated with `ClearTimeoutFlag`, a distinct checkbox state, test-double enumeration, validator warning for the resume interaction, version bump, and a cross-step integration test.
+- **Remaining Risks:** Medium-High confidence. Small-sample p95 basis, the known `resumePrevious:true` interaction gotcha, and the need to visually review the new checkbox glyph in context.

--- a/docs/project-discovery.md
+++ b/docs/project-discovery.md
@@ -28,7 +28,7 @@
 - Package manager: Go modules
 - Dependency manifest: `src/go.mod`
 - Module: `github.com/mxriverlynn/pr9k/src`
-- Current version: `0.7.0` (single source of truth: `src/internal/version/version.go`)
+- Current version: `0.7.1` (single source of truth: `src/internal/version/version.go`)
 - External dependencies: `github.com/charmbracelet/bubbletea` v1.3.10 (TUI framework), `github.com/charmbracelet/lipgloss` v1.1.0 (styling), `github.com/charmbracelet/bubbles` v1.0.0 (viewport widget), `github.com/spf13/cobra` v1.10.2, `golang.org/x/sys` v0.40.0
 
 ### Frameworks and Tooling

--- a/src/internal/steps/steps.go
+++ b/src/internal/steps/steps.go
@@ -39,6 +39,17 @@ type Step struct {
 	// cidfile-driven Terminator path so Docker containers are cleaned up correctly.
 	// Zero means no timeout (the default).
 	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
+	// OnTimeout selects the per-step policy applied when TimeoutSeconds fires.
+	// Accepted values:
+	//   ""         same as "fail" — current behavior: enter error mode and block
+	//              on user input (c/r/q) for the failed step.
+	//   "fail"     explicit form of the default.
+	//   "continue" soft-fail: log the timeout, advance to the next step without
+	//              prompting, and render the step with the StepTimedOutContinuing
+	//              glyph ("[!]"). Intended for unattended runs where the work was
+	//              already partially completed before the timer fired.
+	// Only meaningful when TimeoutSeconds > 0.
+	OnTimeout string `json:"onTimeout,omitempty"`
 	// ResumePrevious, when true, requests that this claude step resume the
 	// previous claude step's session via --resume <session_id>. Five runtime
 	// gates (G1–G5) must all pass; any failure logs the blocking gate and falls

--- a/src/internal/ui/header.go
+++ b/src/internal/ui/header.go
@@ -48,7 +48,8 @@ const (
 	StepActive
 	StepDone
 	StepFailed
-	StepSkipped // displayed as "[-] <name>"
+	StepSkipped            // displayed as "[-] <name>"
+	StepTimedOutContinuing // displayed as "[!] <name>" — step hit its timeoutSeconds but onTimeout=continue let the workflow advance
 )
 
 // HeaderCols is the number of checkbox columns per row; constant to fit 80-column terminals.
@@ -248,6 +249,8 @@ func cellStyle(state StepState) (marker string, nameColor, markerColor lipgloss.
 		return "✗", LightGray, LightGray
 	case StepSkipped:
 		return "-", LightGray, LightGray
+	case StepTimedOutContinuing:
+		return "!", LightGray, LightGray
 	default:
 		return " ", LightGray, LightGray
 	}

--- a/src/internal/ui/log.go
+++ b/src/internal/ui/log.go
@@ -49,6 +49,14 @@ func RetryStepSeparator(stepName string) string {
 	return fmt.Sprintf("── %s (retry) ─────────────", stepName)
 }
 
+// TimeoutContinueBanner returns the one-line log entry written when a step
+// hits its timeoutSeconds and its onTimeout policy is "continue". Mirrors the
+// "timed out after Ns" phrasing used in iteration.jsonl so operators grepping
+// logs see the same string.
+func TimeoutContinueBanner(stepName string, timeoutSeconds int) string {
+	return fmt.Sprintf("── %s timed out after %ds — continuing (onTimeout=continue) ─────────────", stepName, timeoutSeconds)
+}
+
 // CompletionSummary returns the final summary line written to the log body
 // after all iterations and finalize steps have completed.
 // Example output: "Ralph completed after 3 iteration(s) and 2 finalizing tasks."

--- a/src/internal/ui/orchestrate.go
+++ b/src/internal/ui/orchestrate.go
@@ -22,6 +22,15 @@ const (
 type StepRunner interface {
 	RunStep(name string, command []string) error
 	WasTerminated() bool
+	// WasTimedOut reports whether the most recent RunStep ended by a per-step
+	// timeout goroutine (as opposed to natural non-zero exit or user skip).
+	// Runner.WasTimedOut / stepDispatcher.WasTimedOut satisfy this.
+	WasTimedOut() bool
+	// ClearTimeoutFlag resets the executor's timeoutFired bit. Called by
+	// Orchestrate when an onTimeout="continue" policy has consumed the timeout
+	// so the next step's stepDispatcher does not see stale state and emit a
+	// spurious WARN-001 iteration record.
+	ClearTimeoutFlag()
 	WriteToLog(line string)
 }
 
@@ -49,6 +58,12 @@ type ResolvedStep struct {
 	// TimeoutSeconds, when positive, limits the wall-clock time for this step.
 	// Zero means no timeout.
 	TimeoutSeconds int
+	// OnTimeout selects the per-step policy applied when TimeoutSeconds fires.
+	// "" and "fail" block on user input via ModeError (current behavior);
+	// "continue" soft-fails: the step is marked StepTimedOutContinuing and the
+	// workflow advances without prompting. Only meaningful when TimeoutSeconds
+	// is positive.
+	OnTimeout string
 }
 
 // Orchestrate runs steps in sequence. On step failure (non-zero exit, not
@@ -89,6 +104,20 @@ func runStepWithErrorHandling(idx int, step ResolvedStep, runner StepRunner, hea
 
 		if err == nil || runner.WasTerminated() {
 			header.SetStepState(idx, StepDone)
+			return ActionContinue
+		}
+
+		// Soft-fail on timeout: if the step was ended by the per-step timeout
+		// goroutine AND its configured policy is "continue", log the timeout,
+		// clear the executor's timeoutFired flag (so the next step's dispatcher
+		// does not see stale state), mark the step with the distinct glyph, and
+		// advance without blocking on user input. The iteration record still
+		// records status="failed" with a "timed out after Ns" note because
+		// stepStatus maps StepTimedOutContinuing to "failed".
+		if runner.WasTimedOut() && step.OnTimeout == "continue" {
+			runner.WriteToLog(TimeoutContinueBanner(step.Name, step.TimeoutSeconds))
+			runner.ClearTimeoutFlag()
+			header.SetStepState(idx, StepTimedOutContinuing)
 			return ActionContinue
 		}
 

--- a/src/internal/ui/orchestrate_test.go
+++ b/src/internal/ui/orchestrate_test.go
@@ -11,10 +11,14 @@ import (
 // --- Test doubles ---
 
 type stubRunner struct {
-	results       []error // one per RunStep call; nil = success
-	callCount     int
-	wasTerminated bool
-	logLines      []string
+	results           []error // one per RunStep call; nil = success
+	callCount         int
+	wasTerminated     bool
+	wasTimedOut       bool
+	clearTimeoutCalls int
+	// timedOutResults, if non-nil, returns wasTimedOut values per call (overrides wasTimedOut)
+	timedOutResults []bool
+	logLines        []string
 }
 
 func (s *stubRunner) RunStep(_ string, _ []string) error {
@@ -26,21 +30,41 @@ func (s *stubRunner) RunStep(_ string, _ []string) error {
 	return err
 }
 
-func (s *stubRunner) WasTerminated() bool    { return s.wasTerminated }
+func (s *stubRunner) WasTerminated() bool { return s.wasTerminated }
+func (s *stubRunner) WasTimedOut() bool {
+	// callCount is incremented after RunStep, so the "just-returned" call is at index callCount-1.
+	if len(s.timedOutResults) > 0 {
+		idx := s.callCount - 1
+		if idx >= 0 && idx < len(s.timedOutResults) {
+			return s.timedOutResults[idx]
+		}
+	}
+	return s.wasTimedOut
+}
+func (s *stubRunner) ClearTimeoutFlag()      { s.clearTimeoutCalls++; s.wasTimedOut = false }
 func (s *stubRunner) WriteToLog(line string) { s.logLines = append(s.logLines, line) }
 
 // callbackStubRunner is a StepRunner whose RunStep behaviour is controlled by
 // a callback. Use this when you need precise timing control in tests.
 type callbackStubRunner struct {
-	onRunStep       func(name string) error
-	wasTerminatedFn func() bool
-	logLines        []string
+	onRunStep         func(name string) error
+	wasTerminatedFn   func() bool
+	wasTimedOutFn     func() bool
+	clearTimeoutCalls int
+	logLines          []string
 }
 
 func (c *callbackStubRunner) RunStep(name string, _ []string) error {
 	return c.onRunStep(name)
 }
-func (c *callbackStubRunner) WasTerminated() bool    { return c.wasTerminatedFn() }
+func (c *callbackStubRunner) WasTerminated() bool { return c.wasTerminatedFn() }
+func (c *callbackStubRunner) WasTimedOut() bool {
+	if c.wasTimedOutFn == nil {
+		return false
+	}
+	return c.wasTimedOutFn()
+}
+func (c *callbackStubRunner) ClearTimeoutFlag()      { c.clearTimeoutCalls++ }
 func (c *callbackStubRunner) WriteToLog(line string) { c.logLines = append(c.logLines, line) }
 
 type spyHeader struct {
@@ -771,5 +795,154 @@ func TestCaptureMode_ZeroValueIsCaptureLastLine(t *testing.T) {
 	}
 	if CaptureLastLine == CaptureResult {
 		t.Errorf("CaptureLastLine and CaptureResult must be distinct values")
+	}
+}
+
+// --- OnTimeout=continue soft-fail behavior ---
+
+// TOT-1: When a step times out AND its OnTimeout policy is "continue", the
+// orchestrator marks the step with StepTimedOutContinuing, calls
+// ClearTimeoutFlag on the runner, and returns ActionContinue WITHOUT entering
+// ModeError (so no c/r/q prompt blocks an unattended run).
+func TestOrchestrate_TimeoutContinue_DoesNotEnterErrorMode(t *testing.T) {
+	stub := &stubRunner{
+		results:     []error{errors.New("killed by timer")},
+		wasTimedOut: true,
+	}
+	spy := &spyHeader{}
+	actions := make(chan StepAction, 1)
+	h := NewKeyHandler(nil, actions)
+	steps := []ResolvedStep{{Name: "long-step", Command: []string{"x"}, TimeoutSeconds: 60, OnTimeout: "continue"}}
+
+	done := make(chan StepAction, 1)
+	go func() { done <- Orchestrate(steps, stub, spy, h) }()
+
+	select {
+	case result := <-done:
+		if result != ActionContinue {
+			t.Errorf("expected ActionContinue, got %v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Orchestrate blocked — soft-timeout branch did not return")
+	}
+
+	state, ok := spy.lastStateFor(0)
+	if !ok {
+		t.Fatal("no step state recorded")
+	}
+	if state != StepTimedOutContinuing {
+		t.Errorf("expected StepTimedOutContinuing, got %v", state)
+	}
+	if stub.clearTimeoutCalls != 1 {
+		t.Errorf("expected ClearTimeoutFlag called exactly once, got %d", stub.clearTimeoutCalls)
+	}
+	// Confirm the banner was written to the log.
+	var bannerFound bool
+	for _, line := range stub.logLines {
+		if strings.Contains(line, "timed out after 60s") && strings.Contains(line, "onTimeout=continue") {
+			bannerFound = true
+			break
+		}
+	}
+	if !bannerFound {
+		t.Errorf("expected TimeoutContinueBanner in log; got %v", stub.logLines)
+	}
+}
+
+// TOT-2: When OnTimeout is unset (default), a timeout still enters ModeError
+// exactly like today — the policy only activates on explicit "continue".
+func TestOrchestrate_TimeoutDefault_StillEntersErrorMode(t *testing.T) {
+	stub := &stubRunner{
+		results:     []error{errors.New("killed by timer")},
+		wasTimedOut: true,
+	}
+	spy := &spyHeader{}
+	actions := make(chan StepAction, 1)
+	h := NewKeyHandler(nil, actions)
+	steps := []ResolvedStep{{Name: "long-step", Command: []string{"x"}, TimeoutSeconds: 60 /* OnTimeout: "" */}}
+
+	done := make(chan StepAction, 1)
+	go func() { done <- Orchestrate(steps, stub, spy, h) }()
+
+	// Give the goroutine a moment to reach the blocking receive on h.Actions.
+	time.Sleep(30 * time.Millisecond)
+	// Must be in ModeError now — send continue to unblock.
+	h.Actions <- ActionContinue
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Orchestrate did not respond to ActionContinue")
+	}
+
+	state, _ := spy.lastStateFor(0)
+	if state != StepFailed {
+		t.Errorf("expected StepFailed (default policy), got %v", state)
+	}
+	if stub.clearTimeoutCalls != 0 {
+		t.Errorf("ClearTimeoutFlag should not be called on default policy, got %d calls", stub.clearTimeoutCalls)
+	}
+}
+
+// TOT-3: OnTimeout="fail" is the explicit form of the default and must behave
+// identically — timeout still blocks on user input.
+func TestOrchestrate_TimeoutExplicitFail_BehavesLikeDefault(t *testing.T) {
+	stub := &stubRunner{
+		results:     []error{errors.New("killed by timer")},
+		wasTimedOut: true,
+	}
+	spy := &spyHeader{}
+	actions := make(chan StepAction, 1)
+	h := NewKeyHandler(nil, actions)
+	steps := []ResolvedStep{{Name: "long-step", Command: []string{"x"}, TimeoutSeconds: 60, OnTimeout: "fail"}}
+
+	done := make(chan StepAction, 1)
+	go func() { done <- Orchestrate(steps, stub, spy, h) }()
+
+	time.Sleep(30 * time.Millisecond)
+	h.Actions <- ActionContinue
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Orchestrate did not respond to ActionContinue")
+	}
+
+	state, _ := spy.lastStateFor(0)
+	if state != StepFailed {
+		t.Errorf("expected StepFailed, got %v", state)
+	}
+}
+
+// TOT-4: The soft-fail policy is timeout-specific. A non-timeout failure
+// (WasTimedOut=false) with OnTimeout=continue still enters ModeError.
+func TestOrchestrate_NonTimeoutFailure_IgnoresOnTimeoutPolicy(t *testing.T) {
+	stub := &stubRunner{
+		results:     []error{errors.New("exit 1")}, // real failure
+		wasTimedOut: false,                         // not a timeout
+	}
+	spy := &spyHeader{}
+	actions := make(chan StepAction, 1)
+	h := NewKeyHandler(nil, actions)
+	steps := []ResolvedStep{{Name: "broken", Command: []string{"x"}, TimeoutSeconds: 60, OnTimeout: "continue"}}
+
+	done := make(chan StepAction, 1)
+	go func() { done <- Orchestrate(steps, stub, spy, h) }()
+
+	time.Sleep(30 * time.Millisecond)
+	h.Actions <- ActionContinue
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Orchestrate did not respond to ActionContinue")
+	}
+
+	state, _ := spy.lastStateFor(0)
+	if state != StepFailed {
+		t.Errorf("expected StepFailed (OnTimeout policy must not apply to non-timeout failures), got %v", state)
+	}
+	if stub.clearTimeoutCalls != 0 {
+		t.Errorf("ClearTimeoutFlag should not be called on non-timeout failure, got %d calls", stub.clearTimeoutCalls)
 	}
 }

--- a/src/internal/validator/production_steps_test.go
+++ b/src/internal/validator/production_steps_test.go
@@ -359,9 +359,10 @@ func TestCodeReviewPrompt_ContainsSentinel(t *testing.T) {
 }
 
 // TestLoadSteps_TestWritingStep_TimeoutSeconds pins that the "Test writing" step
-// in the shipped config.json has timeoutSeconds: 900. This guards against
-// accidental removal of the conservative cap that prevents runaway test-writing
-// runs from blocking the iteration loop indefinitely.
+// in the shipped config.json has timeoutSeconds: 1800 and onTimeout: "continue".
+// This guards against accidental removal of the soft-fail policy that lets
+// unattended runs proceed past a rare Test-writing overrun, and the cap sized
+// against observed organic p95 (~733s) with generous margin.
 func TestLoadSteps_TestWritingStep_TimeoutSeconds(t *testing.T) {
 	ralphTUIDir := getRalphTUIDir(t)
 	sf, err := steps.LoadSteps(ralphTUIDir)
@@ -372,8 +373,11 @@ func TestLoadSteps_TestWritingStep_TimeoutSeconds(t *testing.T) {
 	for _, s := range sf.Iteration {
 		if s.Name == "Test writing" {
 			found = true
-			if s.TimeoutSeconds != 900 {
-				t.Errorf("Test writing TimeoutSeconds: want 900, got %d", s.TimeoutSeconds)
+			if s.TimeoutSeconds != 1800 {
+				t.Errorf("Test writing TimeoutSeconds: want 1800, got %d", s.TimeoutSeconds)
+			}
+			if s.OnTimeout != "continue" {
+				t.Errorf("Test writing OnTimeout: want \"continue\", got %q", s.OnTimeout)
 			}
 		}
 	}

--- a/src/internal/validator/validator.go
+++ b/src/internal/validator/validator.go
@@ -86,6 +86,7 @@ type vStep struct {
 	BreakLoopIfEmpty   bool     `json:"breakLoopIfEmpty,omitempty"`
 	SkipIfCaptureEmpty *string  `json:"skipIfCaptureEmpty,omitempty"`
 	TimeoutSeconds     *int     `json:"timeoutSeconds,omitempty"`
+	OnTimeout          *string  `json:"onTimeout,omitempty"`
 	ResumePrevious     *bool    `json:"resumePrevious,omitempty"`
 }
 
@@ -452,6 +453,48 @@ func validatePhase(
 				*errs = append(*errs, at("schema", "timeoutSeconds must be a positive integer when set"))
 			} else if *step.TimeoutSeconds > 86400 {
 				*errs = append(*errs, at("schema", "timeoutSeconds must not exceed 86400 (24 hours)"))
+			}
+		}
+
+		// Schema 2d2 — onTimeout: must be "", "fail", or "continue". Warn when set
+		// without a positive timeoutSeconds (the field is inert in that case).
+		if step.OnTimeout != nil {
+			ot := *step.OnTimeout
+			switch ot {
+			case "", "fail", "continue":
+				// valid
+			default:
+				*errs = append(*errs, at("schema", fmt.Sprintf("onTimeout %q is not valid; use \"fail\", \"continue\", or omit the field", ot)))
+			}
+			if ot != "" && (step.TimeoutSeconds == nil || *step.TimeoutSeconds <= 0) {
+				*errs = append(*errs, Error{
+					Severity: SeverityWarning,
+					Category: "schema",
+					Phase:    phaseName,
+					StepName: stepName,
+					Problem:  "onTimeout is set but timeoutSeconds is not; the field has no effect without a positive timeoutSeconds",
+				})
+			}
+			// Warn when onTimeout=continue precedes a step with resumePrevious=true:
+			// the soft-timeout leaves the current step in StepTimedOutContinuing
+			// (stepStatus -> "failed"), so the next step's G2 gate will reject the
+			// resume and fall through to a fresh session. Not a bug, just a gotcha
+			// worth flagging at config time.
+			if ot == "continue" && i+1 < len(steps) {
+				next := steps[i+1]
+				if next.ResumePrevious != nil && *next.ResumePrevious {
+					nextName := next.Name
+					if nextName == "" {
+						nextName = fmt.Sprintf("<unnamed step %d>", i+1)
+					}
+					*errs = append(*errs, Error{
+						Severity: SeverityWarning,
+						Category: "schema",
+						Phase:    phaseName,
+						StepName: stepName,
+						Problem:  fmt.Sprintf("onTimeout=\"continue\" precedes step %q which uses resumePrevious=true; on a soft-timeout path the resume will fall through G2 and start a fresh session", nextName),
+					})
+				}
 			}
 		}
 

--- a/src/internal/version/version.go
+++ b/src/internal/version/version.go
@@ -4,4 +4,4 @@
 package version
 
 // Version is the current pr9k release version.
-const Version = "0.7.0"
+const Version = "0.7.1"

--- a/src/internal/version/version_test.go
+++ b/src/internal/version/version_test.go
@@ -14,10 +14,10 @@ func TestVersion_FollowsSemver(t *testing.T) {
 	}
 }
 
-// TP-005 (issue #145): version must remain at 0.7.0 for this issue.
-// Update this test intentionally when bumping.
-func TestVersion_PinnedAt070(t *testing.T) {
-	if Version != "0.7.0" {
-		t.Errorf("version must remain 0.7.0 for issue #145; got %q — update this test intentionally when bumping", Version)
+// Pins the current release. Update this test intentionally when bumping.
+// 0.7.1: PATCH bump for the onTimeout policy schema addition.
+func TestVersion_PinnedAt071(t *testing.T) {
+	if Version != "0.7.1" {
+		t.Errorf("version must remain 0.7.1 for the onTimeout release; got %q — update this test intentionally when bumping", Version)
 	}
 }

--- a/src/internal/workflow/run.go
+++ b/src/internal/workflow/run.go
@@ -62,7 +62,8 @@ func buildState(vt *vars.VarTable, phase vars.Phase, sessionID, ver string) stat
 }
 
 // StepExecutor is the interface for running workflow steps and capturing command output.
-// *Runner satisfies this interface.
+// *Runner satisfies this interface. WasTimedOut and ClearTimeoutFlag are
+// inherited from ui.StepRunner (embedded above).
 type StepExecutor interface {
 	ui.StepRunner
 	LastCapture() string
@@ -75,9 +76,6 @@ type StepExecutor interface {
 	// (returning false for every id) is safe and correct for test doubles that
 	// do not need to exercise G5.
 	SessionBlacklisted(id string) bool
-	// WasTimedOut reports whether the most recent step was ended by a timeout
-	// goroutine. Returns false once the next step begins.
-	WasTimedOut() bool
 	// WriteRunSummary writes line to both the TUI and the file logger. Used for
 	// the run-level cumulative summary (D13 2c) so it is visible in the TUI and
 	// persisted to disk, unlike WriteToLog which only sends to the TUI.
@@ -163,6 +161,8 @@ func (d *stepDispatcher) RunStep(name string, command []string) error {
 }
 
 func (d *stepDispatcher) WasTerminated() bool    { return d.exec.WasTerminated() }
+func (d *stepDispatcher) WasTimedOut() bool      { return d.exec.WasTimedOut() }
+func (d *stepDispatcher) ClearTimeoutFlag()      { d.exec.ClearTimeoutFlag() }
 func (d *stepDispatcher) WriteToLog(line string) { d.exec.WriteToLog(line) }
 
 // RunHeader is the interface for updating the TUI status header during workflow execution.
@@ -218,11 +218,14 @@ func (s *stateTracker) SetStepState(_ int, state ui.StepState) {
 }
 
 // stepStatus converts a ui.StepState to the IterationRecord Status string.
+// StepTimedOutContinuing maps to "failed" so the iteration log preserves the
+// signal that a timeout fired; setTimeoutNote attaches the "timed out after
+// Ns" note alongside.
 func stepStatus(state ui.StepState) string {
 	switch state {
 	case ui.StepDone, ui.StepActive:
 		return "done"
-	case ui.StepFailed:
+	case ui.StepFailed, ui.StepTimedOutContinuing:
 		return "failed"
 	case ui.StepSkipped:
 		return "skipped"
@@ -233,11 +236,18 @@ func stepStatus(state ui.StepState) string {
 	}
 }
 
-// setTimeoutNote sets rec.Notes to the standard timeout message when the executor
-// reports that the most recent step was ended by a per-step timeout goroutine.
+// setTimeoutNote sets rec.Notes to the standard timeout message when a per-step
+// timeout was the cause of the step ending. Two signals satisfy this: the
+// executor's WasTimedOut flag (the direct signal), or a lastState of
+// StepTimedOutContinuing (the soft-fail policy consumed the flag via
+// ClearTimeoutFlag before this function runs, but the state is preserved).
+// Either signal is sufficient; both are equivalent.
 // SUGG-001: extracted from three near-identical inline blocks in Run.
-func setTimeoutNote(rec *IterationRecord, executor StepExecutor, s steps.Step) {
-	if executor.WasTimedOut() && s.TimeoutSeconds > 0 {
+func setTimeoutNote(rec *IterationRecord, executor StepExecutor, s steps.Step, lastState ui.StepState) {
+	if s.TimeoutSeconds <= 0 {
+		return
+	}
+	if executor.WasTimedOut() || lastState == ui.StepTimedOutContinuing {
 		rec.Notes = fmt.Sprintf("timed out after %ds", s.TimeoutSeconds)
 	}
 }
@@ -438,7 +448,7 @@ func Run(executor StepExecutor, header RunHeader, keyHandler *ui.KeyHandler, cfg
 		rec.InputTokens = disp.capturedStats.InputTokens
 		rec.OutputTokens = disp.capturedStats.OutputTokens
 		rec.SessionID = disp.capturedStats.SessionID
-		setTimeoutNote(&rec, executor, s)
+		setTimeoutNote(&rec, executor, s, st.lastState)
 		if logErr := AppendIterationRecord(executor.ProjectDir(), rec); logErr != nil {
 			executor.WriteToLog(fmt.Sprintf("warning: %v", logErr))
 		}
@@ -567,7 +577,7 @@ func Run(executor StepExecutor, header RunHeader, keyHandler *ui.KeyHandler, cfg
 			rec.InputTokens = disp.capturedStats.InputTokens
 			rec.OutputTokens = disp.capturedStats.OutputTokens
 			rec.SessionID = disp.capturedStats.SessionID
-			setTimeoutNote(&rec, executor, s)
+			setTimeoutNote(&rec, executor, s, th.lastState)
 			if logErr := AppendIterationRecord(executor.ProjectDir(), rec); logErr != nil {
 				executor.WriteToLog(fmt.Sprintf("warning: %v", logErr))
 			}
@@ -700,7 +710,7 @@ func Run(executor StepExecutor, header RunHeader, keyHandler *ui.KeyHandler, cfg
 		rec.InputTokens = disp.capturedStats.InputTokens
 		rec.OutputTokens = disp.capturedStats.OutputTokens
 		rec.SessionID = disp.capturedStats.SessionID
-		setTimeoutNote(&rec, executor, s)
+		setTimeoutNote(&rec, executor, s, th.lastState)
 		if logErr := AppendIterationRecord(executor.ProjectDir(), rec); logErr != nil {
 			executor.WriteToLog(fmt.Sprintf("warning: %v", logErr))
 		}
@@ -768,6 +778,7 @@ func buildStep(workflowDir string, s steps.Step, vt *vars.VarTable, phase vars.P
 			IsClaude:       true,
 			CidfilePath:    cidfile,
 			TimeoutSeconds: s.TimeoutSeconds,
+			OnTimeout:      s.OnTimeout,
 		}, nil
 	}
 	var capMode ui.CaptureMode
@@ -784,6 +795,7 @@ func buildStep(workflowDir string, s steps.Step, vt *vars.VarTable, phase vars.P
 		Command:        ResolveCommand(workflowDir, s.Command, vt, phase),
 		CaptureMode:    capMode,
 		TimeoutSeconds: s.TimeoutSeconds,
+		OnTimeout:      s.OnTimeout,
 	}, nil
 }
 

--- a/src/internal/workflow/run_test.go
+++ b/src/internal/workflow/run_test.go
@@ -49,6 +49,13 @@ type fakeExecutor struct {
 	writeRunSummaryCalls int
 	// wasTimedOut controls the value returned by WasTimedOut().
 	wasTimedOut bool
+	// clearTimeoutFlagCalls counts how many times ClearTimeoutFlag() has been called.
+	clearTimeoutFlagCalls int
+	// onRunStepFull, when set, is invoked at the start of each RunStepFull call
+	// with the current fakeExecutor and the zero-based call index. Tests use it
+	// to mutate state mid-call — e.g. set wasTimedOut=true to simulate the real
+	// Runner's timer firing during execution.
+	onRunStepFull func(f *fakeExecutor, callIdx int)
 	// sessionBlacklist is the set of session IDs returned as blacklisted.
 	sessionBlacklist map[string]bool
 }
@@ -73,6 +80,9 @@ func (f *fakeExecutor) RunStepFull(name string, command []string, captureMode ui
 	f.runStepCalls = append(f.runStepCalls, runStepCall{name, command})
 	f.runStepFullCaptureModes = append(f.runStepFullCaptureModes, captureMode)
 	f.runStepFullTimeouts = append(f.runStepFullTimeouts, timeoutSeconds)
+	if f.onRunStepFull != nil {
+		f.onRunStepFull(f, idx)
+	}
 	if idx < len(f.runStepErrors) && f.runStepErrors[idx] != nil {
 		f.lastCapture = ""
 		return f.runStepErrors[idx]
@@ -87,6 +97,7 @@ func (f *fakeExecutor) RunStepFull(name string, command []string, captureMode ui
 
 func (f *fakeExecutor) WasTerminated() bool               { return false }
 func (f *fakeExecutor) WasTimedOut() bool                 { return f.wasTimedOut }
+func (f *fakeExecutor) ClearTimeoutFlag()                 { f.clearTimeoutFlagCalls++; f.wasTimedOut = false }
 func (f *fakeExecutor) SessionBlacklisted(id string) bool { return f.sessionBlacklist[id] }
 
 func (f *fakeExecutor) RunSandboxedStep(name string, command []string, opts SandboxOptions) error {

--- a/src/internal/workflow/run_timeout_test.go
+++ b/src/internal/workflow/run_timeout_test.go
@@ -397,3 +397,128 @@ func TestBuildStep_Claude_CopiesTimeoutSeconds(t *testing.T) {
 		t.Errorf("ResolvedStep.TimeoutSeconds: want 300, got %d", resolved.TimeoutSeconds)
 	}
 }
+
+// TOT-B1: buildStep non-claude branch copies s.OnTimeout into the ResolvedStep.
+func TestBuildStep_NonClaude_CopiesOnTimeout(t *testing.T) {
+	workflowDir := t.TempDir()
+	vt := vars.New(workflowDir, t.TempDir(), 1)
+	executor := &fakeExecutor{projectDir: t.TempDir()}
+
+	resolved, err := buildStep(
+		workflowDir,
+		steps.Step{IsClaude: false, Command: []string{"true"}, TimeoutSeconds: 300, OnTimeout: "continue"},
+		vt, vars.Iteration, nil, nil, executor, "",
+	)
+	if err != nil {
+		t.Fatalf("buildStep: %v", err)
+	}
+	if resolved.OnTimeout != "continue" {
+		t.Errorf("ResolvedStep.OnTimeout: want %q, got %q", "continue", resolved.OnTimeout)
+	}
+}
+
+// TOT-B2: buildStep claude branch copies s.OnTimeout into the ResolvedStep.
+func TestBuildStep_Claude_CopiesOnTimeout(t *testing.T) {
+	workflowDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workflowDir, "prompts"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "prompts", "p.md"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	vt := vars.New(workflowDir, t.TempDir(), 1)
+	executor := &fakeExecutor{projectDir: t.TempDir()}
+
+	resolved, err := buildStep(
+		workflowDir,
+		steps.Step{Name: "c", IsClaude: true, Model: "sonnet", PromptFile: "p.md", TimeoutSeconds: 300, OnTimeout: "continue"},
+		vt, vars.Iteration, nil, nil, executor, "",
+	)
+	if err != nil {
+		t.Fatalf("buildStep: %v", err)
+	}
+	if resolved.OnTimeout != "continue" {
+		t.Errorf("ResolvedStep.OnTimeout: want %q, got %q", "continue", resolved.OnTimeout)
+	}
+}
+
+// TOT-X1: Cross-step integration — step A is a non-claude step with
+// TimeoutSeconds and OnTimeout=continue whose subprocess the fakeExecutor
+// "times out" (timer fires mid-step via onRunStepFull hook + error return);
+// step B is a non-claude step that succeeds. Iteration log must contain:
+//   - step A: exactly one record, status="failed", notes="timed out after Ns"
+//   - step B: exactly one record, status="done", no spurious WARN-001 "timed out after 0s" record
+//
+// This covers V4/V13 from the plan review: without ClearTimeoutFlag, the
+// residual WasTimedOut=true would fire stepDispatcher's onTimeoutRetry at the
+// start of step B and emit a bogus "failed" record for step B.
+func TestRun_OnTimeoutContinue_DoesNotLeakTimeoutFlagToNextStep(t *testing.T) {
+	projectDir := makeCacheDir(t)
+	executor := &fakeExecutor{
+		projectDir: projectDir,
+		// Step A errors; step B succeeds.
+		runStepErrors: []error{fmt.Errorf("killed by timer"), nil},
+	}
+	// Simulate the real Runner: wasTimedOut starts false and is set true by the
+	// timer goroutine during step A's execution. The hook fires at the start of
+	// each RunStepFull call; for idx==0 (step A) we set wasTimedOut=true so the
+	// post-return check observes a timeout. For idx==1 (step B) we leave it
+	// alone — if ClearTimeoutFlag was called after step A's soft-fail, it is
+	// already false.
+	executor.onRunStepFull = func(f *fakeExecutor, callIdx int) {
+		if callIdx == 0 {
+			f.wasTimedOut = true
+		}
+	}
+
+	header := &fakeRunHeader{}
+
+	cfg := RunConfig{
+		WorkflowDir: t.TempDir(),
+		Iterations:  1,
+		Steps: []steps.Step{
+			{Name: "step-a", IsClaude: false, Command: []string{"true"}, TimeoutSeconds: 60, OnTimeout: "continue"},
+			{Name: "step-b", IsClaude: false, Command: []string{"true"}},
+		},
+	}
+
+	kh := newTestKeyHandler()
+	Run(executor, header, kh, cfg)
+
+	recs := readIterationLog(t, projectDir)
+
+	// Count records per step.
+	recsByStep := map[string][]IterationRecord{}
+	for _, r := range recs {
+		recsByStep[r.StepName] = append(recsByStep[r.StepName], r)
+	}
+
+	// step-a: exactly one record, status="failed", notes="timed out after 60s".
+	a := recsByStep["step-a"]
+	if len(a) != 1 {
+		t.Fatalf("step-a: want 1 record, got %d: %+v", len(a), a)
+	}
+	if a[0].Status != "failed" {
+		t.Errorf("step-a Status: want %q, got %q", "failed", a[0].Status)
+	}
+	if a[0].Notes != "timed out after 60s" {
+		t.Errorf("step-a Notes: want %q, got %q", "timed out after 60s", a[0].Notes)
+	}
+
+	// step-b: exactly one record, status="done", no timeout note.
+	b := recsByStep["step-b"]
+	if len(b) != 1 {
+		t.Fatalf("step-b: want 1 record (no spurious WARN-001 leak), got %d: %+v", len(b), b)
+	}
+	if b[0].Status != "done" {
+		t.Errorf("step-b Status: want %q, got %q — WasTimedOut flag leaked across steps", "done", b[0].Status)
+	}
+	if b[0].Notes != "" {
+		t.Errorf("step-b Notes: want empty, got %q — stale timeout note leaked to next step", b[0].Notes)
+	}
+
+	// ClearTimeoutFlag was called at least once by the orchestrate-layer soft-fail branch.
+	if executor.clearTimeoutFlagCalls < 1 {
+		t.Errorf("expected ClearTimeoutFlag to be called on the soft-fail branch, got %d calls", executor.clearTimeoutFlagCalls)
+	}
+}

--- a/src/internal/workflow/workflow.go
+++ b/src/internal/workflow/workflow.go
@@ -167,6 +167,17 @@ func (r *Runner) WasTimedOut() bool {
 	return r.timeoutFired
 }
 
+// ClearTimeoutFlag resets the timed-out flag to false. The ui layer calls this
+// when an onTimeout="continue" policy has consumed the timeout signal and the
+// workflow is advancing. Without this reset, the next step's stepDispatcher
+// would see a stale true from WasTimedOut() and fire its WARN-001 synthetic
+// iteration record for a step that never timed out.
+func (r *Runner) ClearTimeoutFlag() {
+	r.processMu.Lock()
+	defer r.processMu.Unlock()
+	r.timeoutFired = false
+}
+
 // SessionBlacklisted reports whether id is in the session blacklist. Safe for
 // concurrent use; acquires processMu internally.
 func (r *Runner) SessionBlacklisted(id string) bool {

--- a/src/internal/workflow/workflow_timeout_test.go
+++ b/src/internal/workflow/workflow_timeout_test.go
@@ -295,3 +295,38 @@ func TestTimeoutGracePeriod_IsTenSeconds(t *testing.T) {
 		t.Errorf("timeoutGracePeriod = %v, want %v — update docs/how-to/setting-step-timeouts.md if this changes", timeoutGracePeriod, want)
 	}
 }
+
+// TOT-R1: ClearTimeoutFlag resets timeoutFired to false. Verifies the executor
+// side of the onTimeout=continue fix — without this, a residual timeoutFired
+// would leak across dispatcher boundaries.
+func TestRunner_ClearTimeoutFlag_ResetsTimedOutFlag(t *testing.T) {
+	r, log, _ := newCapturingRunner(t)
+	defer func() { _ = log.Close() }()
+	r.timeoutGraceOverride = 200 * time.Millisecond
+
+	stepDone := make(chan error, 1)
+	go func() {
+		stepDone <- r.RunStepFull("slow", []string{"sh", "-c", "trap '' TERM; sleep 5"}, ui.CaptureLastLine, 1)
+	}()
+
+	select {
+	case <-stepDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunStepFull did not complete within 5 seconds")
+	}
+
+	if !r.WasTimedOut() {
+		t.Fatal("WasTimedOut should be true after the timer fires")
+	}
+
+	r.ClearTimeoutFlag()
+	if r.WasTimedOut() {
+		t.Error("WasTimedOut should be false after ClearTimeoutFlag()")
+	}
+
+	// Idempotent: calling again does not panic or change state.
+	r.ClearTimeoutFlag()
+	if r.WasTimedOut() {
+		t.Error("WasTimedOut should remain false after a second ClearTimeoutFlag()")
+	}
+}

--- a/workflow/config.json
+++ b/workflow/config.json
@@ -23,7 +23,7 @@
     { "name": "Feature work",          "isClaude": true,  "model": "sonnet", "promptFile": "feature-work.md" },
     { "name": "Get post-feature diff", "isClaude": false, "command": ["git", "diff", "{{STARTING_SHA}}..HEAD", "--stat"], "captureAs": "PRE_REVIEW_DIFF", "captureMode": "fullStdout" },
     { "name": "Test planning",         "isClaude": true,  "model": "opus",   "promptFile": "test-planning.md" },
-    { "name": "Test writing",     "isClaude": true,  "model": "sonnet", "promptFile": "test-writing.md", "timeoutSeconds": 900 },
+    { "name": "Test writing",     "isClaude": true,  "model": "sonnet", "promptFile": "test-writing.md", "timeoutSeconds": 1800, "onTimeout": "continue" },
     { "name": "Summarize to issue", "isClaude": false, "command": ["scripts/post_issue_summary", "{{ISSUE_ID}}"] },
     { "name": "Close issue",      "isClaude": false, "command": ["scripts/close_gh_issue", "{{ISSUE_ID}}"] },
     { "name": "Git push",         "isClaude": false, "command": ["git", "push"] }

--- a/workflow/prompts/feature-work.md
+++ b/workflow/prompts/feature-work.md
@@ -24,11 +24,11 @@ Implement github issue #{{ISSUE_ID}} in the current branch (do not switch branch
 
 ## After the loop
 
-1. Check off each completed Acceptance Criterion in github issue #{{ISSUE_ID}}.
-2. Add a comment to github issue {{ISSUE_ID}} with your progress and the TDD summary.
-3. Append your progress to progress.txt.
-4. Append all deferred work to deferred.txt.
-5. Commit changes in a single commit.
+5. Check off each completed Acceptance Criterion in github issue #{{ISSUE_ID}}.
+6. Add a comment to github issue {{ISSUE_ID}} with your progress and the TDD summary.
+7. Append your progress to progress.txt.
+8. Append all deferred work to deferred.txt.
+9. Commit changes in a single commit.
 
 Never commit progress.txt
 Never commit deferred.txt


### PR DESCRIPTION
## Summary

Adds a per-step `onTimeout` policy field (`"fail"` | `"continue"`, default `"fail"`) so a configured `timeoutSeconds` cap can be treated as a soft failure — log, advance, and mark with a distinct glyph — instead of parking the TUI on a `c`/`r`/`q` prompt. Intended for unattended runs where a Claude step's work is typically partial-but-valuable by the time the timer fires.

The bundled "Test writing" step adopts this policy: `timeoutSeconds` rises from `900` → `1800` (~2.5× the observed organic p95 of ~733s across 15 runs; prior 900s was below median) and `onTimeout` is set to `"continue"`. Also bumps the version to `0.7.1` and restores consecutive numbering in `feature-work.md` so `TestPrompts_NumberedStepsConsecutive` passes.

### Policy behavior

| `onTimeout`              | TUI glyph | Error mode? | Iteration record          |
| ------------------------ | --------- | ----------- | ------------------------- |
| `""` / `"fail"` (default) | `[✗]`     | Yes (`c`/`r`/`q`) | `status: "failed"`, `notes: "timed out after Ns"` |
| `"continue"`             | `[!]`     | No — advances silently | `status: "failed"`, `notes: "timed out after Ns"` |

Both policies record `status: "failed"` in `.pr9k/iteration.jsonl` so structured logs retain the timeout signal either way — only the runtime routing differs.

### Mechanism

- New `ui.StepState` value `StepTimedOutContinuing` (glyph `[!]`) is distinct from `StepFailed` so soft-timeouts are visually separable from hard failures in the checkbox grid.
- `ui.StepRunner` gains `WasTimedOut()` and `ClearTimeoutFlag()`. After `Orchestrate` takes the continue branch it writes the `TimeoutContinueBanner` line, calls `ClearTimeoutFlag()` on the runner, and sets the step state. Without the clear, the next step's `stepDispatcher.WasTimedOut()` would read stale `true` and emit a spurious `WARN-001` synthetic iteration record (caught by adversarial review).
- `setTimeoutNote` accepts `lastState` so the iteration-log note still attaches after `ClearTimeoutFlag` consumed the direct signal — either `executor.WasTimedOut()` or `lastState == StepTimedOutContinuing` is sufficient.
- `stepStatus` maps `StepTimedOutContinuing` to `"failed"` (not a new status string) so existing iteration-log consumers keep working.

### Validator

- Rejects `onTimeout` values other than `""`, `"fail"`, `"continue"` as schema errors.
- Warns when `onTimeout` is set without a positive `timeoutSeconds` (field is inert).
- Warns when `onTimeout: "continue"` precedes a step with `resumePrevious: true` — the soft-timeout path leaves the previous step in `StepTimedOutContinuing` (maps to `"failed"`), so G2 rejects the resume and the dependent step silently falls through to a fresh session.

## Key file changes

| File | Purpose |
| ---- | ------- |
| `src/internal/steps/steps.go` | Add `OnTimeout` field to the JSON `Step` schema |
| `src/internal/ui/header.go` | New `StepTimedOutContinuing` state + `[!]` glyph |
| `src/internal/ui/log.go` | `TimeoutContinueBanner` log line |
| `src/internal/ui/orchestrate.go` | Continue-branch routing + `ClearTimeoutFlag` call |
| `src/internal/workflow/run.go` | Map state to `"failed"`; `setTimeoutNote` lastState arg |
| `src/internal/workflow/workflow.go` | `Runner.ClearTimeoutFlag()` under `processMu` |
| `src/internal/validator/validator.go` | Schema 2d2: `onTimeout` values + gotcha warnings |
| `workflow/config.json` | "Test writing" → `timeoutSeconds: 1800`, `onTimeout: "continue"` |
| `src/internal/version/version.go` | `0.7.0` → `0.7.1` (PATCH — additive schema field) |
| `workflow/prompts/feature-work.md` | Restore consecutive numbering (5–9) after TDD loop section |

## Key test scenario changes

| File | Purpose |
| ---- | ------- |
| `src/internal/ui/orchestrate_test.go` | Continue-path routing: banner written, `ClearTimeoutFlag` called, state set, no error mode |
| `src/internal/workflow/run_timeout_test.go` | End-to-end: `setTimeoutNote` attaches via `lastState` after `ClearTimeoutFlag`; stale-flag does not leak across steps |
| `src/internal/workflow/workflow_timeout_test.go` | `Runner.ClearTimeoutFlag()` resets `timeoutFired` under mutex |
| `src/internal/validator/production_steps_test.go` | Production config accepts new `onTimeout` value |
| `src/internal/version/version_test.go` | Version pin updated to `0.7.1` |

## Test Plan

- [ ] `make ci` passes (test, lint, format, vet, vulncheck, mod-tidy, build)
- [ ] `cd src && go test -race ./...` passes, including new timeout tests
- [ ] Manual: run `./bin/pr9k -n 1` against a target repo, confirm a "Test writing" step that exceeds 1800s lands on `[!]` glyph and the workflow advances to "Summarize to issue" without prompting
- [ ] Manual: run with `onTimeout: "garbage"` in a workflow config and confirm validator fatal error pre-flight
- [ ] Manual: set `onTimeout: "continue"` on a step whose next step has `resumePrevious: true` and confirm validator warning at startup
- [ ] Verify `.pr9k/iteration.jsonl` after a soft-timeout contains `status: "failed"` and `notes: "timed out after 1800s"`
- [ ] Confirm `./bin/pr9k --version` reports `0.7.1`
