### PR TITLE
UI layout, and image processing fixes

### DIFF
--- a/docs/code-packages/sandbox.md
+++ b/docs/code-packages/sandbox.md
@@ -65,7 +65,7 @@ Constructs the complete `docker run ...` argv. The returned slice begins with `"
 
 - **`--rm`** — container is destroyed when it exits; no residue on the host.
 - **`-i`** — stdin stays attached (claude reads from it).
-- **`--init`** — PID 1 is a minimal init; zombie reaping is handled correctly.
+- **No `--init` flag** — the image's ENTRYPOINT (`tini --`) already runs as PID 1 and handles signal forwarding plus zombie reaping. Adding `--init` would inject Docker's own tini at PID 1, push the image's tini to PID 7, and produce a `Tini is not running as PID 1` WARN at the start of every step.
 - **`--cidfile <path>`** — docker writes the 64-char container ID to `<path>` as soon as the container starts. The terminator reads this file to address `docker kill` at the right container.
 - **`-u <uid>:<gid>`** — container runs as the host user; files written to the bind mount are owned by the invoking user.
 - **`--mount type=bind,...`** — bind mounts use key=value syntax (`--mount type=bind,source=...,target=...`) rather than the shorthand `-v dir:target`; this avoids argument injection via colons in path names.
@@ -145,7 +145,7 @@ Constructs the `docker run -it ...` argv for an interactive `bash` shell used by
 
 - The host project directory is bind-mounted at `ContainerRepoPath` (read-write) and is the working directory, so the user lands in the project tree.
 - Entrypoint is `bash` instead of `claude` (the `claude` binary is still on `PATH` inside the shell).
-- Otherwise the shape matches `BuildInteractiveArgs`: `-it`, `--rm`, `--init`, profile mount, `CLAUDE_CONFIG_DIR`, optional `-e TERM` passthrough.
+- Otherwise the shape matches `BuildInteractiveArgs`: `-it`, `--rm`, profile mount, `CLAUDE_CONFIG_DIR`, optional `-e TERM` passthrough.
 
 ## Package
 

--- a/docs/coding-standards/versioning.md
+++ b/docs/coding-standards/versioning.md
@@ -31,7 +31,7 @@ When you are about to make a change, ask: "does this break one of the four items
 
 ## `0.y.z` — initial development
 
-The current release is `0.8.0`. Per semver §4, while MAJOR is `0`, **anything may change at any time** and the public API is not considered stable. For this repo, that means:
+The current release is `0.8.1`. Per semver §4, while MAJOR is `0`, **anything may change at any time** and the public API is not considered stable. For this repo, that means:
 
 - Backwards-incompatible changes to the CLI surface or `config.json` schema during `0.y.z` bump the **MINOR** (e.g. `0.6.0` → `0.7.0`), not the major.
 - Backwards-compatible additions and bug fixes both bump the **PATCH** (e.g. `0.6.0` → `0.6.1`).

--- a/docs/features/docker-sandbox.md
+++ b/docs/features/docker-sandbox.md
@@ -51,7 +51,6 @@ pr9k constructs the following command for every claude step. Values in `<ANGLE_B
 docker run                                              \
   --rm                                                  \
   -i                                                    \
-  --init                                                \
   --cidfile <TMP>/ralph-<UNIQUE>.cid                    \
   -u <UID>:<GID>                                        \
   --mount type=bind,source=<PROJECT_DIR>,target=/home/agent/workspace  \
@@ -84,7 +83,7 @@ docker run                                              \
 
 - `--rm` — container is ephemeral; deleted on exit.
 - `-i` — attach stdin. Only safe because `RunSandboxedStep` provides explicit empty stdin (`bytes.NewReader(nil)`) to prevent Bubble Tea's raw-mode keyboard reader from being inherited by docker.
-- `--init` — install tini as PID 1 so SIGTERM is forwarded to claude and zombie processes are reaped.
+- No `--init` flag is passed. The image's ENTRYPOINT is already `tini --`, which runs as PID 1 inside the container and handles SIGTERM forwarding and zombie reaping. Passing `--init` would inject a second tini at PID 1, pushing the image's tini to PID 7 and producing a `Tini is not running as PID 1` WARN at the start of every step.
 - `--cidfile <tmp>/ralph-<unique>.cid` — capture the container ID so `Terminate()` can call `docker kill <cid>` rather than signaling the host docker CLI process (which would orphan the container). The cidfile path is unique per step under `os.TempDir()`.
 - `-u <UID>:<GID>` — run as the invoking host user. Files written to the bind-mounted repo are owned by the host user, so subsequent shell steps (`git`, `gh`) work without permission errors.
 - `--mount type=bind,source=<PROJECT_DIR>,target=/home/agent/workspace` — bind-mount the target repo. `<PROJECT_DIR>` is the `--project-dir` value (default: `os.Getwd()` + `filepath.EvalSymlinks`). The `--mount` syntax is used instead of `-v` to avoid argument injection via colons in path names. The workflow bundle (`<WORKFLOW_DIR>`) is NOT mounted.

--- a/docs/features/sandbox-subcommand.md
+++ b/docs/features/sandbox-subcommand.md
@@ -162,7 +162,7 @@ type dockerInteractiveFunc func(args []string, stdin io.Reader, stdout, stderr i
 ## `BuildInteractiveArgs` shape
 
 ```
-docker run -it --rm --init
+docker run -it --rm
   -u <uid>:<gid>
   --mount type=bind,source=<profileDir>,target=/home/agent/.claude
   -e CLAUDE_CONFIG_DIR=/home/agent/.claude
@@ -183,7 +183,7 @@ Differences from `BuildRunArgs`:
 ## `BuildShellArgs` shape
 
 ```
-docker run -it --rm --init
+docker run -it --rm
   -u <uid>:<gid>
   --mount type=bind,source=<projectDir>,target=/home/agent/workspace
   --mount type=bind,source=<profileDir>,target=/home/agent/.claude

--- a/docs/features/tui-display.md
+++ b/docs/features/tui-display.md
@@ -152,6 +152,14 @@ func NewStatusHeader(maxStepsAcrossPhases int) *StatusHeader {
 }
 ```
 
+### Resize Handling and Min-Size Guard
+
+On `tea.WindowSizeMsg`, the model recomputes the viewport size from the new terminal dimensions and the (constant) grid row count, and returns `tea.ClearScreen` in its cmd batch. The clear is required because Bubble Tea's `standard_renderer` only invalidates its in-memory line cache on resize — it does not erase the alt-screen — so any prior over-tall render that scrolled the alt-screen leaves stale rows above the new render's cursor home, producing visibly shuffled grid rows.
+
+`View()` short-circuits with a single-line "Terminal too small — resize to at least 60×N" placeholder when `m.width < uichrome.MinTerminalWidth (60)` or `m.height < chromeRows + 1`, where `chromeRows = 1 (top border) + gridRows + 4 (two HRules + footer + bottom border)`. The minimum is computed from `gridRows` (not from `uichrome.MinTerminalHeight`) because workflows with many steps need a taller minimum than the workflow-builder TUI's static `16`. Mouse handling is short-circuited under the same precondition so coordinate translation does not run against the placeholder.
+
+This mirrors the workflow-builder TUI's D48 guard at `internal/workflowedit/render_frame.go:30`, but parameterized on grid height. Tests in `model_test.go`: `TestView_FrameNeverExceedsHeight`, `TestView_TooSmall_RendersPlaceholder`, `TestView_AfterResizeSmallThenLarge_RendersFullFrame`, `TestWindowSizeMsg_ReturnsClearScreenCmd`, `TestMouseMsg_TooSmall_Ignored`.
+
 ### Phase Switching
 
 `SetPhaseSteps` replaces the current step name list and re-renders all checkbox slots. Call this at the start of each phase to swap the header to the new phase's step set. Trailing slots beyond the current phase's step count are cleared. Panics if `len(names)` exceeds the grid capacity — this is a programming error, not a user-reachable path:

--- a/docs/how-to/setting-up-docker-sandbox.md
+++ b/docs/how-to/setting-up-docker-sandbox.md
@@ -130,7 +130,7 @@ The profile directory is created automatically if it doesn't exist (mode `0700`)
 If something about `sandbox --interactive` isn't working and you want to isolate the problem, you can launch the same container by hand:
 
 ```bash
-docker run -it --rm --init \
+docker run -it --rm \
   -u $(id -u):$(id -g) \
   -v ~/.claude:/home/agent/.claude \
   -e CLAUDE_CONFIG_DIR=/home/agent/.claude \

--- a/docs/plans/run-tui-resize-overflow.md
+++ b/docs/plans/run-tui-resize-overflow.md
@@ -1,0 +1,190 @@
+# Run-mode TUI breaks on terminal zoom / resize
+
+## Problem Statement
+
+**Symptom.** When the terminal is resized (font zoom in/out, window resize, tab font change), the run-mode TUI's chrome frame is rendered with no top border, and the checkbox grid appears to start mid-screen with rows in apparently shuffled order. The user observed it "after transitioning from initialize to iteration phase" but identified the actual trigger as having zoomed the terminal at some earlier point.
+
+**Expected behavior.** The TUI must re-flow cleanly on every terminal resize event. Either the frame fits inside the new dimensions, or a clear "terminal too small" placeholder is shown — never an oversized frame that gets clipped by the terminal.
+
+**Conditions.**
+- Run-mode TUI (`internal/ui`), not the workflow-builder TUI (which already handles this — see E1).
+- Triggered any time `m.height < chromeRows + 1`, where `chromeRows = 1 + gridRows + 4` and `gridRows = ceil(maxStepsAcrossPhases / 4)`.
+- Phase transition is incidental: the grid row count is allocated once at startup at the maximum across all phases (E4); transitioning from initialize → iteration only fills in previously-empty cells, making the (already-broken) layout visually obvious.
+
+**Impact.** TUI is unusable on small terminals and after some zoom operations until the user happens to resize back to a large enough size. The top border, iteration title, and first grid row(s) get pushed off the top of the alt-screen.
+
+## Evidence Summary
+
+- **E1** — Run-mode TUI lacks a min-size guard. The workflow-builder TUI (`internal/workflowedit/render_frame.go:30`) returns "Terminal too small — resize to at least 60×16" when `msg.Width < uichrome.MinTerminalWidth || msg.Height < uichrome.MinTerminalHeight`. `internal/ui/model.go` has no equivalent. The constants exist (`uichrome/constants.go:5,8`) but `internal/ui` never imports them for guard purposes.
+
+- **E2** — `WindowSizeMsg` clamps viewport to ≥1 but does NOT clamp the total frame to `m.height`. `internal/ui/model.go:334-354`:
+  ```go
+  gridRows := len(m.header.header.Rows)
+  chromeRows := 1 + gridRows + 1 + 1 + 1 + 1
+  vpHeight := m.height - chromeRows
+  if vpHeight < 1 {
+      vpHeight = 1
+  }
+  ```
+  When `m.height ≤ chromeRows`, `vpHeight` is forced to 1, so emitted output is `chromeRows + 1 = gridRows + 7` lines — guaranteed to exceed `m.height`.
+
+- **E3** — `View()` always emits the full chrome unconditionally (`internal/ui/model.go:398-513`). Order: top border, every grid row, hrule, every viewport line, hrule, footer, bottom border. There is no "skip top border / collapse grid" branch for short terminals. Total output length is purely a function of `gridRows + vpHeight + 5`, never of `m.height`.
+
+- **E4** — Header row count is fixed at startup (`cmd/pr9k/main.go:158-159`, `internal/ui/header.go:88-98`):
+  ```go
+  maxSteps := max(len(stepFile.Initialize), len(stepFile.Iteration), len(stepFile.Finalize))
+  header := ui.NewStatusHeader(maxSteps)
+  ```
+  `SetPhaseSteps` (`header.go:183-198`) only writes/clears cells; it never reallocates `Rows`. **Phase transitions do not change `gridRows`.** This refutes the original "step list grows" hypothesis.
+
+- **E5** — `WindowSizeMsg` is the only place that re-budgets `vpHeight`. `m.log.SetSize` is never called outside the `WindowSizeMsg` branch. Bubble Tea hooks `SIGWINCH` (verified in vendored `bubbletea@v1.3.10/tty.go`) and re-sends `WindowSizeMsg` on every resize, so the resize wiring is correct — the bug is in what the handler does, not whether it fires.
+
+- **E6** — Help modal already has explicit overflow handling (`internal/ui/model.go:528-536`) — `if modalH > m.height && m.height >= 2 { modalLines = modalLines[:m.height]; ...pin bottom rows }`. This same problem in the base frame has no equivalent code, confirming the gap was thought about in one place and missed in another.
+
+- **E7** — `HeaderCols = 4` is a hard-coded constant (`header.go:57`), never adapted to width. Width does not affect `gridRows`.
+
+- **E8** — `WrapLine` (`uichrome/chrome.go:12-24`) truncates via `MaxWidth`, does not multi-line wrap. So narrow terminals cannot inflate `gridRows` via per-row wrap.
+
+- **E9** — Coverage gap. `model_test.go` has `TestWindowSizeMsg_VerySmall_ViewportClampsToOne`, `TestWindowSizeMsg_Width3_VpWidthClampsToOne`, `TestView_ZeroDimensions_NoPanic` — all assert non-panic and `vpHeight ≥ 1`. None assert `len(strings.Split(View(), "\n")) <= m.height`. The very class of bug — frame taller than terminal — has no test guard.
+
+## Root Cause Analysis (revised after validation)
+
+There are **two distinct bugs**, both triggered by terminal resize:
+
+**Bug A (primary, explains the user's screenshot at 172×39).** Bubble Tea's `standard_renderer` on `WindowSizeMsg` calls `repaint()` — which only invalidates its in-memory line cache — but does NOT emit an alt-screen erase or reset the cursor home (validator V4, confirmed by reading `bubbletea@v1.3.10/standard_renderer.go:213-264, 630-635`). When a previous render had overflowed the terminal (e.g. during a transient mid-zoom size), the alt-screen scrolled and the renderer's cursor-position assumption diverged from the terminal's actual cell layout. After the user finished zooming, the new render writes lines starting from the stale cursor, producing the interleaved/shuffled rows the user observed (row2, row3, row1, row0 missing — V2).
+
+**Bug B (latent, would trigger on genuinely small terminals).** Run-mode `View()` always emits `gridRows + vpHeight + 5` lines with `vpHeight` clamped to ≥ 1 (E2, E3). When the terminal is shorter than the chrome's intrinsic minimum, the frame overflows. Unlike the workflow-builder TUI (E1) and the help-modal overflow path (E6), there is no min-size guard. This is what *produces* the over-tall render in the first place (the input to Bug A's stale-cursor problem) AND would also break the layout independently on truly small terminals.
+
+Phase transitions are coincidental (E4): the grid is pre-allocated to `maxStepsAcrossPhases` at startup, so transitioning from initialize to iteration only populates previously-empty cells. The user noticed the broken layout at the phase transition because that's when populated cells made the breakage visually obvious — the underlying corrupt render state had been there since the zoom event.
+
+## Coding Standards Reference
+
+- **`docs/coding-standards/tui-rendering.md`** — Plain-text-first ANSI composition (single styling pass), `lipgloss.Width()` for visual width, render file decomposition (`render_*.go` per component). The fix will follow these (no styling-pass changes; the new branch is a single `if` + early return).
+- **Inferred from `internal/workflowedit/render_frame.go:30`** — When the terminal is below the min-size threshold, return a single-string placeholder "Terminal too small — resize to at least WxH". The run-mode TUI should mirror this pattern for consistency.
+- **`docs/coding-standards/testing.md`** — Race detector required (`make test` already uses `-race`); add tests that assert frame line count against `m.height` to close coverage gap E9.
+
+## Planned Fix (revised)
+
+**One-sentence summary.** Force a full alt-screen clear on every `WindowSizeMsg` to recover from any stale renderer state (fixes Bug A, the user's actual symptom), AND add a min-size guard to `View()` so the renderer never produces an over-tall frame in the first place (fixes Bug B, the precondition for Bug A), AND add tests covering both the line-count invariant and a resize-down-then-up scenario.
+
+### File 1: `src/internal/ui/model.go` — `WindowSizeMsg` handler
+
+**Change.** Return a `tea.ClearScreen` cmd on every `WindowSizeMsg` so the alt-screen is fully erased and the renderer's cursor-position assumption is reset before the next frame writes:
+
+```go
+case tea.WindowSizeMsg:
+    m.width = msg.Width
+    m.height = msg.Height
+    gridRows := len(m.header.header.Rows)
+    chromeRows := 1 + gridRows + 1 + 1 + 1 + 1
+    vpHeight := m.height - chromeRows
+    if vpHeight < 1 {
+        vpHeight = 1
+    }
+    vpWidth := m.width - 2
+    if vpWidth < 1 {
+        vpWidth = 1
+    }
+    m.log.SetSize(vpWidth, vpHeight)
+    var lcmd tea.Cmd
+    m.log, lcmd = m.log.Update(msg)
+    cmds = append(cmds, lcmd, tea.ClearScreen) // ← NEW: erase any stale alt-screen content
+```
+
+- Justified by **V4** (Bubble Tea's `repaint()` does not erase the alt-screen, leaving stale rows from the previous over-tall render at the top of the screen).
+- This is the actual fix for the user's reported symptom at 172×39 (V1, V2).
+
+### File 2: `src/internal/ui/model.go` — `View()` min-size guard
+
+**Change.** After computing `m.width` / `m.height`, add an early-return branch:
+
+```go
+func (m Model) View() string {
+    gridRows := len(m.header.header.Rows)
+    chromeRows := 1 + gridRows + 1 + 1 + 1 + 1
+    minHeight := chromeRows + 1 // chrome + at least one viewport row
+    if m.width < uichrome.MinTerminalWidth || m.height < minHeight {
+        return fmt.Sprintf("Terminal too small — resize to at least %d×%d",
+            uichrome.MinTerminalWidth, minHeight)
+    }
+    // ...rest of existing View() body unchanged...
+}
+```
+
+- Justified by **E1, E2, E3, E6**.
+- Mirrors `internal/workflowedit/render_frame.go:30`.
+- `minHeight` is computed dynamically from `gridRows` (constant per-run, V6) rather than using the static `uichrome.MinTerminalHeight=16`, because workflows with many steps need a taller minimum.
+- Side benefit: the early return short-circuits the help-modal block too, so help-modal-on-narrow-terminal corner cases are also fixed (V8).
+
+### File 3: `src/internal/ui/model.go` — mouse handler precondition
+
+**Change.** Mouse-event handling at `model.go:237-321` assumes a fitted frame for coordinate translation. Add the same min-size precondition so mouse events are ignored while the placeholder is showing:
+
+```go
+case tea.MouseMsg:
+    gridRows := len(m.header.header.Rows)
+    minH := 1 + gridRows + 5 + 1
+    if m.width < uichrome.MinTerminalWidth || m.height < minH {
+        return m, nil // ignore mouse events while in too-small placeholder mode
+    }
+    // ...existing body...
+```
+
+- Justified by **V9**.
+
+### File 4: `src/internal/ui/model_test.go`
+
+**Change.** Add tests:
+
+1. `TestView_FrameNeverExceedsHeight` — table-driven over (width, height, stepCounts). Assert `len(strings.Split(m.View(), "\n")) <= m.height` for every combination.
+2. `TestView_TooSmall_RendersPlaceholder` — given `height < chromeRows + 1`, assert View output is the placeholder string and contains no border glyphs (`╭`, `╮`, `╰`, `╯`).
+3. `TestView_AfterResizeSmallThenLarge_RendersFullFrame` — send a small `WindowSizeMsg`, then a normal one; assert second `View()` emits the full chrome and that the WindowSizeMsg path returns a `tea.ClearScreen` cmd in its batch (use a recorder fake to capture cmds).
+4. `TestWindowSizeMsg_ReturnsClearScreenCmd` — assert every `WindowSizeMsg` Update returns a batch containing `tea.ClearScreen`. This is the regression guard for Bug A.
+
+- Justified by **E9, V7**.
+- Note (V7): Unit tests on `View()` cannot detect the renderer-level stale-cursor artifact. Test 4 covers the *cmd contract* — that the model issues the clear — which is the strongest model-level guarantee available without spinning up a full Bubble Tea program.
+
+### Manual reproduction protocol
+
+Document in plan only (not committed code). To verify Bug A is fixed:
+
+1. Start pr9k against any repo with a multi-step workflow.
+2. While the TUI is running, zoom the terminal in (Cmd+= on macOS Terminal/iTerm) several times rapidly to force the frame to overflow transiently.
+3. Zoom back out to a comfortable size.
+4. Trigger a re-render (e.g., wait for the next phase transition or step state change).
+5. Verify the top border is intact and grid rows are in the expected order.
+
+### What this fix does NOT change
+
+- `vpHeight < 1 → 1` clamp stays — defensive against `bubbles/viewport` receiving zero dimensions; the new guard ensures `View()` never renders a frame in that regime anyway.
+- `HeaderCols = 4` stays. Adapting columns to width is a separate concern.
+- The "frame shrinks gracefully" / progressive-degradation alternative was considered and rejected: it doubles the render code paths, and the workflow-builder TUI already established the placeholder pattern. Consistency wins.
+
+## Adjustments Made (after adversarial validation)
+
+- **V1, V2 (root cause was wrong):** Original plan attributed the symptom solely to small-terminal overflow. Validator showed 172×39 is far above chrome height and that row-shuffling cannot be produced by simple top-clipping. Root Cause section now distinguishes Bug A (renderer stale-cursor after resize) and Bug B (frame overflow on small terminals).
+- **V4 (fix was incomplete):** Added `tea.ClearScreen` cmd to the `WindowSizeMsg` handler. This is now the primary fix for the user's reported symptom; the min-size guard is the secondary, preventive fix.
+- **V7 (test gap):** Added explicit regression test that asserts `tea.ClearScreen` is included in the cmd batch from `WindowSizeMsg`, plus a manual reproduction protocol for the renderer-level artifact a unit test cannot catch.
+- **V8 (side benefit not noted):** Documented that the new guard short-circuits help-modal narrow-terminal cases.
+- **V9 (mouse handler):** Added File 3 — mouse handler short-circuit so coordinate translation doesn't operate against the placeholder.
+- **V6 (minor phrasing):** Acknowledged that `minHeight` is computed once per run (since `gridRows` is constant per E4), not per-WindowSizeMsg.
+
+## Confidence Assessment
+
+- **HIGH** that the combined fix (`tea.ClearScreen` + min-size guard) addresses the user's actual reported symptom. The `tea.ClearScreen` directly fixes the V4 stale-cursor pathway that produced the shuffled-row screenshot at 172×39.
+- **MEDIUM** that no other resize-related artifacts remain. `bubbles/viewport`'s own resize behavior (R5 below) was not exhaustively audited — `m.log.SetSize` followed by `m.log.Update(msg)` is the project's existing pattern and is preserved unchanged.
+
+## Remaining Risks
+
+1. **`bubbles/viewport` stale lines (V's R5).** The viewport may itself cache wrapped lines that don't invalidate cleanly on `SetSize`. If so, content inside the log panel could still look stale across resizes even after the screen clear. Mitigation: rely on existing word-wrap-on-resize code path in `log_panel.go`; flag as a separate investigation if it surfaces.
+2. **OS window title length (V's R4).** `titleString()` includes `heartbeatSuffix` ("⋯ thinking (Ns)") which could grow long. Not a render bug but worth noting.
+3. **Manual reproduction is required.** Test 4 (cmd-contract regression) is necessary but not sufficient; only the manual zoom-then-zoom-back protocol can fully verify Bug A is fixed. CI cannot reproduce real terminal alt-screen behavior.
+4. **`tea.ClearScreen` causes a brief flash** on every resize. This is the cost of correctness; users only see it when they resize, which is rare.
+
+## Final Summary
+
+- **Root cause:** Bubble Tea's `standard_renderer` does not erase the alt-screen on `WindowSizeMsg` — it only invalidates its line cache — so any over-tall render that scrolled the alt-screen during a transient mid-zoom size leaves stale rows above the new render's cursor home, producing the shuffled-row layout the user observed at 172×39 (Bug A); separately, the run-mode `View()` has no min-size guard so it can produce over-tall renders in the first place (Bug B).
+- **Fix:** Return `tea.ClearScreen` from the `WindowSizeMsg` handler so every resize fully erases the alt-screen, AND add a min-size guard to `View()` that returns a "Terminal too small" placeholder when the terminal is below `MinTerminalWidth × (chromeRows+1)`, mirroring the workflow-builder TUI's pattern, AND short-circuit mouse handling under that same precondition.
+- **Why correct:** V4 confirmed via reading vendored `bubbletea/standard_renderer.go:213-264, 630-635` that `repaint()` does not emit any alt-screen erase; V2 confirmed the row shuffling is consistent with stale-cursor + new-render interleaving and inconsistent with simple top-clipping; the `internal/workflowedit` TUI already uses this min-size pattern (E1).
+- **Validation outcome:** Original min-size-guard-only plan was refuted by V1/V2/V4 as a phantom fix for the screenshot at 172×39; plan now addresses both the renderer artifact (primary) and the underlying overflow precondition (secondary).
+- **Remaining risks:** `bubbles/viewport` may have its own stale-line cache that this fix doesn't address; `tea.ClearScreen` causes a brief flash on resize; manual repro protocol is required because CI cannot reproduce real alt-screen behavior.

--- a/docs/plans/sandbox-tini-warning.md
+++ b/docs/plans/sandbox-tini-warning.md
@@ -1,0 +1,149 @@
+# Tini WARN at start of every claude step
+
+## Problem Statement
+
+**Symptom.** Every claude step in pr9k prints these stderr lines just before claude itself starts:
+```
+[stderr] [WARN  tini (7)] Tini is not running as PID 1 and isn't registered as a child subreaper.
+[stderr] Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
+[stderr] To fix the problem, use the -s option or set the environment variable TINI_SUBREAPER to register Tini as a child subreaper, or run Tini as PID 1.
+```
+
+**Expected behavior.** No tini warning. The container's init handling is either correct (tini at PID 1) or silent (tini is gone).
+
+**Conditions.** Every claude step (`BuildRunArgs`), every interactive sandbox session (`BuildInteractiveArgs`), and every sandbox shell (`BuildShellArgs`). The warning is in three command builders, but the underlying cause is shared.
+
+**Impact.** Cosmetic — log pollution. Each claude step's `.jsonl` and TUI log gets three garbage stderr lines. Functionally harmless: the docker-injected tini at PID 1 *does* reap zombies correctly, the image's redundant tini at PID 7 does not but is also not the one that needs to.
+
+## Evidence Summary
+
+- **E1** — Image ENTRYPOINT is already tini. `docker inspect docker/sandbox-templates:claude-code` returns:
+  ```json
+  Entrypoint: ["tini","--"]
+  Cmd: ["claude","--dangerously-skip-permissions"]
+  ```
+  So unmodified, the image runs `tini -- claude ...` as PID 1.
+
+- **E2** — pr9k passes `--init` to every docker run invocation. `src/internal/sandbox/command.go:40` (`BuildRunArgs`), `:111` (`BuildInteractiveArgs`), `:139` (`BuildShellArgs`):
+  ```go
+  args := []string{
+      "docker", "run",
+      "--rm",
+      "-i",
+      "--init",
+      ...
+  }
+  ```
+  Docker's `--init` injects `/sbin/docker-init` (which is tini) as PID 1 inside the container, then execs the image's ENTRYPOINT as a child.
+
+- **E3** — Layering produces "tini at PID 7". With `--init` + image ENTRYPOINT `["tini", "--"]`, the process tree inside the container is:
+  - PID 1: `docker-init` (Docker's tini)
+  - PID 7: `tini --` (image's tini)
+  - PID 8+: `claude ...`
+
+  The image's inner tini detects it is not PID 1 and is not registered as a subreaper via `prctl(PR_SET_CHILD_SUBREAPER)` — hence the WARN at startup.
+
+- **E4** — Documentation explicitly justifies `--init` as zombie reaping. `docs/features/docker-sandbox.md:87`:
+  > `--init` — install tini as PID 1 so SIGTERM is forwarded to claude and zombie processes are reaped.
+
+  This rationale is correct for the *outer* tini, but redundant given the image already has its own tini ENTRYPOINT (E1). The doc was written without knowledge of the image's ENTRYPOINT.
+
+- **E5** — Three places hard-code `--init` and three tests assert it. Tests:
+  - `src/internal/sandbox/command_test.go:51` `assertContainsFlag(t, args, "--init")`
+  - `src/internal/sandbox/command_test.go:185` `expectedPrefixOrder := []string{"docker", "run", "--rm", "-i", "--init", "--cidfile"}`
+  - `src/internal/sandbox/command_test.go:479` `wantFlags := []string{"-it", "--rm", "--init"}` (interactive)
+  - `src/internal/sandbox/command_test.go:637` `wantFlags := []string{"-it", "--rm", "--init"}` (shell)
+  - `src/cmd/pr9k/sandbox_interactive_test.go:310` and `src/cmd/pr9k/sandbox_shell_test.go:219` assert `--init` in command shape
+
+  All tests will need to be updated to assert `--init` is **absent** (or just stop asserting it).
+
+- **E6** — Termination wiring is PID-1-agnostic on the host side. `src/internal/sandbox/terminator.go` calls `docker kill --signal=<SIG> <cid>` against the container ID; the daemon delivers the signal to whichever process is PID 1 inside the container. Both docker-init and the image's tini are tini-class init processes with equivalent SIGTERM-forwarding-and-zombie-reaping semantics, so removing `--init` does not regress termination behavior.
+
+- **E7** — Sibling docs `docs/features/docker-sandbox.md`, `docs/features/sandbox-subcommand.md`, `docs/how-to/setting-up-docker-sandbox.md`, `docs/code-packages/sandbox.md` all reference `--init` in the docker run shape. They will need touch-ups consistent with the fix.
+
+## Root Cause Analysis
+
+The image `docker/sandbox-templates:claude-code` already has `tini --` as its ENTRYPOINT (E1). pr9k additionally passes `--init` to `docker run` (E2), which injects Docker's own tini at PID 1. The result is two tinis in series: docker-init at PID 1, the image's tini at PID 7 (E3). The inner tini correctly detects it is neither PID 1 nor registered as a subreaper and emits the WARN. The outer tini fully covers signal forwarding and zombie reaping, so the inner tini is redundant; nothing relies on it being present beyond its own existence in the image.
+
+## Coding Standards Reference
+
+- **`docs/coding-standards/documentation.md`** — Feature docs ship with the feature; updating CLAUDE.md when adding new doc files; keeping doc code blocks consistent with production code. Applies to docs touch-ups for `--init` removal across `docs/features/docker-sandbox.md`, `docs/features/sandbox-subcommand.md`, `docs/how-to/setting-up-docker-sandbox.md`, `docs/code-packages/sandbox.md`, `docs/audits/new-user-stress-test.md`.
+- **`docs/coding-standards/testing.md`** — Race detector required (already in `make test`). Test changes here are signature-level argv assertions — no concurrency concerns.
+- **ADR `docs/adr/20260413160000-require-docker-sandbox.md`** — Docker is a required runtime for claude steps. The fix preserves this; no ADR change needed.
+- **Inferred from code** — `BuildRunArgs` is a pure argv builder with no side effects; tests assert argv shape verbatim. The fix follows the same shape.
+
+## Planned Fix
+
+**One-sentence summary.** Remove `--init` from all three docker run argv builders so the image's existing `tini --` ENTRYPOINT runs as PID 1, eliminating the redundant inner tini and its WARN.
+
+### File 1: `src/internal/sandbox/command.go`
+
+**Change.** Remove the `"--init",` line from `BuildRunArgs` (line 40), `BuildInteractiveArgs` (line 111), and `BuildShellArgs` (line 139). Update the godoc on `BuildRunArgs` if it mentions `--init` (it does not currently).
+
+- Justified by **E1, E2, E3, E6**.
+
+### File 2: `src/internal/sandbox/command_test.go`
+
+**Change.** Remove `--init` from the four assertions cited in E5:
+- Line 51: drop the `assertContainsFlag(t, args, "--init")` call (or change to assertNotContainsFlag).
+- Line 185: remove `"--init"` from `expectedPrefixOrder`.
+- Lines 479, 637: remove `"--init"` from `wantFlags` slices.
+
+Add positive regression tests asserting `--init` is **absent** for ALL THREE builders (mandatory, not optional — V7) so re-introduction in any one site is caught:
+
+```go
+func TestBuildRunArgs_NoDoubleInit(t *testing.T)         { /* assert no "--init" in argv */ }
+func TestBuildInteractiveArgs_NoDoubleInit(t *testing.T) { /* same */ }
+func TestBuildShellArgs_NoDoubleInit(t *testing.T)       { /* same */ }
+```
+
+### File 3: `src/cmd/pr9k/sandbox_interactive_test.go` and `src/cmd/pr9k/sandbox_shell_test.go`
+
+**Change.** Remove `"--init",` from the expected argv slices at lines 310 and 219 respectively.
+
+### File 4: Documentation
+
+**Change.** Remove `--init` references from:
+- `docs/features/docker-sandbox.md:54` (argv example), `:87` (`--init` justification bullet — replace with a one-liner explaining the image's ENTRYPOINT handles tini).
+- `docs/features/sandbox-subcommand.md:165, 186` (example commands).
+- `docs/how-to/setting-up-docker-sandbox.md:133` (example command — but this is a user-facing doc, see Open Question 1 below).
+- `docs/code-packages/sandbox.md:68, 148` (package contract).
+- `docs/audits/new-user-stress-test.md:135` — leave alone (audit log of a past observation, not a current claim).
+
+### What this fix does NOT change
+
+- The image. We're not modifying the image's ENTRYPOINT — we're stopping the duplicate.
+- Termination behavior. Docker still forwards SIGTERM to PID 1, which is now the image's tini, which forwards to claude. Same behavior as before.
+- Any other docker run flags.
+
+## Alternatives Considered (and Rejected)
+
+- **Set `TINI_SUBREAPER=1` env var** — silences the WARN but leaves the redundant inner tini and the wrong subreaper semantics. Treats the symptom, not the cause.
+- **Pass `-s` to inner tini** — would require overriding ENTRYPOINT, which has the same effect as just removing `--init` (the cleaner option) and is more invasive.
+- **Remove tini from the image** — image is upstream (`docker/sandbox-templates`), not under our control. Even if it were, the image is reasonable on its own; the redundancy is on our side.
+
+## Validation
+
+Will dispatch adversarial-validator before implementation. Expected challenges:
+
+1. **Does removing `--init` regress signal forwarding?** No — image's tini handles SIGTERM identically (same binary, same default behavior).
+2. **Could the image's ENTRYPOINT change in a future image update, breaking us?** Possible. The fix is robust if ENTRYPOINT remains tini-or-equivalent. Worth noting as remaining risk.
+3. **Does any sandbox flow rely on docker-init's specific behavior?** Not based on E6 — `terminator.go` interacts with the docker daemon via cidfile, not with PID 1 directly.
+
+## Adjustments After Validation
+
+- **V3:** Rephrased E6 from "it's the same binary" to "tini-class init processes with equivalent semantics" — same conclusion, more accurate phrasing.
+- **V7:** Made the `NoDoubleInit` regression test mandatory for all three builders (was parenthetical).
+- **V9:** Image is referenced by floating tag `docker/sandbox-templates:claude-code` with no SHA pin. If a future image push changes ENTRYPOINT away from tini, claude/bash would run as PID 1 with no signal forwarder and the fix would silently regress. Documented as the top remaining risk; mitigation (digest pinning or a startup ENTRYPOINT check) is out of scope for this fix but worth a follow-up.
+
+## Final Summary
+
+- **Root cause:** The image `docker/sandbox-templates:claude-code` already has `tini --` as its ENTRYPOINT, and pr9k passes `--init` to `docker run`, so Docker injects its own tini at PID 1 and the image's tini ends up as a child at PID 7, where it correctly detects it isn't PID 1 and emits the WARN.
+- **Fix:** Remove `--init` from `BuildRunArgs`, `BuildInteractiveArgs`, and `BuildShellArgs`; the image's tini becomes PID 1 with no behavior change. Update tests and docs to match.
+- **Why correct:** `docker inspect` confirms the image's ENTRYPOINT is tini (E1); `terminator.go` uses `docker kill` against the container ID and is PID-1-agnostic on the host side (E6, V1); ENTRYPOINT semantics mean trailing `bash`/`claude` argv override CMD, not ENTRYPOINT (V2).
+- **Validation outcome:** Validator confirmed termination, ENTRYPOINT/CMD semantics, test enumeration, doc enumeration, and absence of hidden docker-init features. Two minor plan-text tightenings applied; image-pin remains the top open risk.
+- **Remaining risks:** Floating image tag (no SHA pin) means a future image change could leave the container with no init; no CI guard exists. Plan does not pin the image (out of scope).
+
+## Open Questions
+
+1. The `setting-up-docker-sandbox.md` how-to is a user-facing copy-paste recipe for `pr9k sandbox --interactive`. The fix updates this to drop `--init` from the example so it matches the binary's actual argv.

--- a/src/cmd/pr9k/sandbox_interactive_test.go
+++ b/src/cmd/pr9k/sandbox_interactive_test.go
@@ -307,7 +307,6 @@ func TestSandboxInteractive_ArgsIncludeBindMountAndInteractive(t *testing.T) {
 	// Must contain: -it, profile bind-mount, CLAUDE_CONFIG_DIR env, uid mapping.
 	wants := []string{
 		"-it",
-		"--init",
 		"--rm",
 		"-u 501:20",
 		"type=bind,source=" + profileDir + ",target=/home/agent/.claude",

--- a/src/cmd/pr9k/sandbox_shell_test.go
+++ b/src/cmd/pr9k/sandbox_shell_test.go
@@ -216,7 +216,6 @@ func TestSandboxShell_ArgsIncludeBindMountsAndBash(t *testing.T) {
 	wants := []string{
 		"-it",
 		"--rm",
-		"--init",
 		"-u 501:20",
 		"type=bind,source=" + projectDir + ",target=/home/agent/workspace",
 		"type=bind,source=" + profileDir + ",target=/home/agent/.claude",

--- a/src/internal/sandbox/command.go
+++ b/src/internal/sandbox/command.go
@@ -37,7 +37,11 @@ func BuildRunArgs(
 		"docker", "run",
 		"--rm",
 		"-i",
-		"--init",
+		// No --init: the image's ENTRYPOINT is already `tini --`, so docker's
+		// own tini would run as PID 1 and the image's tini would end up at PID 7
+		// and emit a "not running as PID 1" WARN on every step. Removing --init
+		// lets the image's tini run as PID 1 with equivalent signal-forwarding
+		// and zombie-reaping semantics.
 		"--cidfile", cidfile,
 		"-u", fmt.Sprintf("%d:%d", uid, gid),
 		"--mount", fmt.Sprintf("type=bind,source=%s,target=%s", projectDir, ContainerRepoPath),
@@ -108,7 +112,7 @@ func BuildInteractiveArgs(profileDir string, uid, gid int) []string {
 		"docker", "run",
 		"-it",
 		"--rm",
-		"--init",
+		// No --init: image's ENTRYPOINT is `tini --`. See BuildRunArgs comment.
 		"-u", fmt.Sprintf("%d:%d", uid, gid),
 		"--mount", fmt.Sprintf("type=bind,source=%s,target=%s", profileDir, ContainerProfilePath),
 		"-e", "CLAUDE_CONFIG_DIR=" + ContainerProfilePath,
@@ -136,7 +140,7 @@ func BuildShellArgs(projectDir, profileDir string, uid, gid int) []string {
 		"docker", "run",
 		"-it",
 		"--rm",
-		"--init",
+		// No --init: image's ENTRYPOINT is `tini --`. See BuildRunArgs comment.
 		"-u", fmt.Sprintf("%d:%d", uid, gid),
 		"--mount", fmt.Sprintf("type=bind,source=%s,target=%s", projectDir, ContainerRepoPath),
 		"--mount", fmt.Sprintf("type=bind,source=%s,target=%s", profileDir, ContainerProfilePath),

--- a/src/internal/sandbox/command_test.go
+++ b/src/internal/sandbox/command_test.go
@@ -48,7 +48,6 @@ func TestBuildRunArgs_GoldenArgv(t *testing.T) {
 
 	assertContainsFlag(t, args, "--rm")
 	assertContainsFlag(t, args, "-i")
-	assertContainsFlag(t, args, "--init")
 	assertContainsConsecutive(t, args, "--cidfile", testCidfile)
 	assertContainsConsecutive(t, args, "-u", "501:20")
 	assertContainsConsecutive(t, args, "--mount", fmt.Sprintf("type=bind,source=%s,target=%s", testProjectDir, ContainerRepoPath))
@@ -182,7 +181,7 @@ func TestBuildRunArgs_FlagOrder(t *testing.T) {
 		nil, nil, "", testModel, "", "prompt")
 
 	// Verify the fixed-position flags appear in the expected order.
-	expectedPrefixOrder := []string{"docker", "run", "--rm", "-i", "--init", "--cidfile"}
+	expectedPrefixOrder := []string{"docker", "run", "--rm", "-i", "--cidfile"}
 	for i, expected := range expectedPrefixOrder {
 		if i >= len(args) {
 			t.Fatalf("args too short; missing %q at position %d", expected, i)
@@ -476,7 +475,7 @@ func TestBuildRunArgs_ContainerEnv_ValueWithEqualsPassesThrough(t *testing.T) {
 func TestBuildInteractiveArgs_Shape(t *testing.T) {
 	args := BuildInteractiveArgs(testProfileDir, testUID, testGID)
 
-	wantFlags := []string{"-it", "--rm", "--init"}
+	wantFlags := []string{"-it", "--rm"}
 	for _, flag := range wantFlags {
 		if indexOf(args, flag) < 0 {
 			t.Errorf("argv missing %q; got %v", flag, args)
@@ -634,7 +633,7 @@ func TestBuildRunArgs_ResumeSessionID_Empty(t *testing.T) {
 func TestBuildShellArgs_Shape(t *testing.T) {
 	args := BuildShellArgs(testProjectDir, testProfileDir, testUID, testGID)
 
-	wantFlags := []string{"-it", "--rm", "--init"}
+	wantFlags := []string{"-it", "--rm"}
 	for _, flag := range wantFlags {
 		if indexOf(args, flag) < 0 {
 			t.Errorf("argv missing %q; got %v", flag, args)
@@ -700,5 +699,33 @@ func TestBuildShellArgs_ForwardsTERMWhenSet(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("argv missing consecutive `-e TERM` pair; got %v", args)
+	}
+}
+
+// --- Regression: --init must NOT appear in any argv builder.
+//
+// The image's ENTRYPOINT is already `tini --`, so passing --init to docker run
+// stacks two tinis and produces a "Tini is not running as PID 1" WARN at the
+// start of every step. See docs/plans/sandbox-tini-warning.md.
+
+func TestBuildRunArgs_NoDoubleInit(t *testing.T) {
+	args := BuildRunArgs(testProjectDir, testProfileDir, testUID, testGID, testCidfile,
+		nil, nil, "", testModel, "", "prompt")
+	if indexOf(args, "--init") >= 0 {
+		t.Errorf("BuildRunArgs must NOT include --init (image ENTRYPOINT is tini); argv: %v", args)
+	}
+}
+
+func TestBuildInteractiveArgs_NoDoubleInit(t *testing.T) {
+	args := BuildInteractiveArgs(testProfileDir, testUID, testGID)
+	if indexOf(args, "--init") >= 0 {
+		t.Errorf("BuildInteractiveArgs must NOT include --init (image ENTRYPOINT is tini); argv: %v", args)
+	}
+}
+
+func TestBuildShellArgs_NoDoubleInit(t *testing.T) {
+	args := BuildShellArgs(testProjectDir, testProfileDir, testUID, testGID)
+	if indexOf(args, "--init") >= 0 {
+		t.Errorf("BuildShellArgs must NOT include --init (image ENTRYPOINT is tini); argv: %v", args)
 	}
 }

--- a/src/internal/ui/model.go
+++ b/src/internal/ui/model.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -8,6 +9,25 @@ import (
 
 	"github.com/mxriverlynn/pr9k/src/internal/uichrome"
 )
+
+// minHeight returns the minimum terminal height required to render the full
+// run-mode chrome plus at least one viewport row. Computed from the configured
+// step count (gridRows is fixed for the lifetime of the process — see header.go
+// NewStatusHeader). Used by View() to gate the placeholder render and by the
+// mouse handler to short-circuit coordinate translation when the placeholder
+// is showing.
+func (m Model) minHeight() int {
+	gridRows := len(m.header.header.Rows)
+	chromeRows := 1 + gridRows + 1 + 1 + 1 + 1 // top + grid + 2 hrules + footer + bottom
+	return chromeRows + 1
+}
+
+// tooSmall reports whether the terminal is below the chrome's minimum size.
+// View() returns a placeholder string in that case rather than emit an
+// over-tall frame the alt-screen would clip from the top.
+func (m Model) tooSmall() bool {
+	return m.width < uichrome.MinTerminalWidth || m.height < m.minHeight()
+}
 
 // headerModel wraps StatusHeader and applies header messages from the
 // orchestration goroutine (sent via headerProxy → program.Send).
@@ -217,6 +237,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Update returns. The fresh LastOutput() is read in View().
 
 	case tea.MouseMsg:
+		// While the placeholder is showing, mouse coordinate translation does
+		// not match the rendered output, so ignore mouse events entirely.
+		if m.tooSmall() {
+			break
+		}
 		// On any mouse event while in ModeSelect, clear the "just released"
 		// committed-shortcut flag so that SelectShortcuts is restored before
 		// the new event is processed (a subsequent press or wheel after a drag
@@ -351,7 +376,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.log.SetSize(vpWidth, vpHeight)
 		var lcmd tea.Cmd
 		m.log, lcmd = m.log.Update(msg)
-		cmds = append(cmds, lcmd)
+		// tea.ClearScreen forces a full alt-screen erase before the next render.
+		// Bubble Tea's standard_renderer.repaint() on WindowSizeMsg only invalidates
+		// its in-memory line cache — it does NOT erase the alt-screen. Without this,
+		// any previous over-tall render that scrolled the alt-screen leaves stale
+		// rows above the new render's cursor home, producing visibly shuffled rows
+		// after a zoom event.
+		cmds = append(cmds, lcmd, tea.ClearScreen)
 
 	case HeartbeatTickMsg:
 		// Delegate to StatusHeader (D23). The ticker is owned by main.go —
@@ -382,6 +413,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // rules between grid/log and log/footer can use ├─┤ T-junction glyphs
 // that visually connect to the │ side borders.
 func (m Model) View() string {
+	// Min-size guard: if the terminal is smaller than the chrome's intrinsic
+	// minimum, render a single-line placeholder rather than an over-tall frame
+	// that the alt-screen would clip from the top. Mirrors the workflow-builder
+	// guard at internal/workflowedit/render_frame.go:30.
+	if m.tooSmall() {
+		return fmt.Sprintf("Terminal too small — resize to at least %d×%d",
+			uichrome.MinTerminalWidth, m.minHeight())
+	}
+
 	title := m.titleString()
 	innerWidth := m.width - 2
 	if innerWidth < 0 {

--- a/src/internal/ui/model_test.go
+++ b/src/internal/ui/model_test.go
@@ -2339,7 +2339,7 @@ func TestView_FrameNeverExceedsHeight(t *testing.T) {
 		{"too-small-zero", 0, 0, 1},
 		{"too-small-1x1", 1, 1, 1},
 		{"too-small-height-just-below-min", 80, 6, 1}, // gridRows=1, minH=8
-		{"exact-min-height", 80, 8, 1},                 // gridRows=1, minH=8
+		{"exact-min-height", 80, 8, 1},                // gridRows=1, minH=8
 	}
 
 	for _, tc := range cases {

--- a/src/internal/ui/model_test.go
+++ b/src/internal/ui/model_test.go
@@ -1670,9 +1670,11 @@ func TestView_StatusLine_NarrowTerminal_TruncatesStatusText(t *testing.T) {
 	actions := make(chan StepAction, 10)
 	kh := NewKeyHandler(func() {}, actions)
 	m := NewModel(header, kh, "v1.0").WithStatusRunner(sr)
-	m.width = 32 // innerWidth = 30
+	// Use the minimum renderable width (uichrome.MinTerminalWidth=60). Below
+	// that, the View() guard returns a placeholder rather than the chrome.
+	m.width = 60 // innerWidth = 58
 	m.height = 24
-	m.log.SetSize(28, 10)
+	m.log.SetSize(56, 10)
 
 	out := m.View()
 	plain := stripANSI(out)
@@ -2268,6 +2270,165 @@ type mockStatusReader struct {
 func (r *mockStatusReader) Enabled() bool      { return r.enabled }
 func (r *mockStatusReader) HasOutput() bool    { return r.hasOutput }
 func (r *mockStatusReader) LastOutput() string { return r.output }
+
+// --- Resize / overflow guard tests (run-tui-resize-overflow) ---
+
+// newTestModelWithSteps builds a Model whose header is sized to stepCount
+// (so gridRows = ceil(stepCount/HeaderCols)).
+func newTestModelWithSteps(t *testing.T, stepCount int) Model {
+	t.Helper()
+	header := NewStatusHeader(stepCount)
+	names := make([]string, stepCount)
+	for i := range names {
+		names[i] = "s"
+	}
+	header.SetPhaseSteps(names)
+	actions := make(chan StepAction, 10)
+	kh := NewKeyHandler(func() {}, actions)
+	return NewModel(header, kh, "pr9k v0.0.0-test")
+}
+
+// batchContains walks the cmd tree returned from tea.Batch and reports whether
+// any leaf cmd has the same identity as want. tea.ClearScreen is a sentinel
+// function value, so identity comparison via reflect.ValueOf().Pointer() works.
+func batchContains(cmd tea.Cmd, want tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+	// Execute the batch to expose its children. tea.Batch returns a cmd that
+	// when invoked returns a tea.BatchMsg containing the child cmds.
+	msg := cmd()
+	switch m := msg.(type) {
+	case tea.BatchMsg:
+		for _, c := range m {
+			if cmdIdentityEqual(c, want) {
+				return true
+			}
+			if batchContains(c, want) {
+				return true
+			}
+		}
+	default:
+		return cmdIdentityEqual(cmd, want)
+	}
+	return false
+}
+
+func cmdIdentityEqual(a, b tea.Cmd) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	// Compare by invoking and matching message type+value: tea.ClearScreen
+	// returns clearScreenMsg{} (an unexported package type), so the value
+	// equality path catches it.
+	ma, mb := a(), b()
+	return ma == mb
+}
+
+func TestView_FrameNeverExceedsHeight(t *testing.T) {
+	cases := []struct {
+		name      string
+		width     int
+		height    int
+		stepCount int
+	}{
+		{"normal-80x24-1step", 80, 24, 1},
+		{"normal-172x39-13step", 172, 39, 13},
+		{"narrow-60x20-4step", 60, 20, 4},
+		{"too-small-40x10-13step", 40, 10, 13},
+		{"too-small-zero", 0, 0, 1},
+		{"too-small-1x1", 1, 1, 1},
+		{"too-small-height-just-below-min", 80, 6, 1}, // gridRows=1, minH=8
+		{"exact-min-height", 80, 8, 1},                 // gridRows=1, minH=8
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestModelWithSteps(t, tc.stepCount)
+			next, _ := m.Update(tea.WindowSizeMsg{Width: tc.width, Height: tc.height})
+			m = next.(Model)
+
+			out := m.View()
+			lineCount := strings.Count(out, "\n") + 1
+			if tc.height > 0 && lineCount > tc.height {
+				t.Errorf("View() output has %d lines, exceeds height=%d:\n%s",
+					lineCount, tc.height, out)
+			}
+		})
+	}
+}
+
+func TestView_TooSmall_RendersPlaceholder(t *testing.T) {
+	m := newTestModelWithSteps(t, 13) // gridRows=4, minH=9
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 5})
+	m = next.(Model)
+
+	out := m.View()
+	if !strings.HasPrefix(out, "Terminal too small") {
+		t.Errorf("expected placeholder string, got: %q", out)
+	}
+	for _, glyph := range []string{"╭", "╮", "╰", "╯", "├", "┤"} {
+		if strings.Contains(out, glyph) {
+			t.Errorf("placeholder contains border glyph %q; got: %q", glyph, out)
+		}
+	}
+}
+
+func TestView_AfterResizeSmallThenLarge_RendersFullFrame(t *testing.T) {
+	m := newTestModelWithSteps(t, 4)
+
+	// First, a too-small size.
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 20, Height: 5})
+	m = next.(Model)
+	if !strings.HasPrefix(m.View(), "Terminal too small") {
+		t.Fatalf("expected placeholder after small resize")
+	}
+
+	// Then resize back up.
+	next, _ = m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = next.(Model)
+
+	out := m.View()
+	if strings.HasPrefix(out, "Terminal too small") {
+		t.Errorf("expected full frame after resize-up, still got placeholder")
+	}
+	if !strings.Contains(out, "╭") {
+		t.Errorf("expected full frame to contain top-left border glyph; got:\n%s", out)
+	}
+}
+
+func TestWindowSizeMsg_ReturnsClearScreenCmd(t *testing.T) {
+	m := newTestModelWithSteps(t, 4)
+	_, cmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	if cmd == nil {
+		t.Fatal("WindowSizeMsg returned nil cmd; expected batch including tea.ClearScreen")
+	}
+	if !batchContains(cmd, tea.ClearScreen) {
+		t.Errorf("WindowSizeMsg batch does not contain tea.ClearScreen")
+	}
+}
+
+func TestMouseMsg_TooSmall_Ignored(t *testing.T) {
+	m := newTestModelWithSteps(t, 13)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 30, Height: 5})
+	m = next.(Model)
+
+	// Send a left-press mouse event in placeholder mode. Should not panic
+	// and should not trigger ModeSelect.
+	prevMode := m.keys.handler.Mode()
+	next, _ = m.Update(tea.MouseMsg{
+		X:      5,
+		Y:      3,
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+	})
+	m = next.(Model)
+	if m.keys.handler.Mode() != prevMode {
+		t.Errorf("mouse press in placeholder mode changed key mode from %v to %v",
+			prevMode, m.keys.handler.Mode())
+	}
+}
 
 // stripANSI removes ANSI escape sequences from s for plain-text comparisons.
 func stripANSI(s string) string {

--- a/src/internal/version/version.go
+++ b/src/internal/version/version.go
@@ -4,4 +4,4 @@
 package version
 
 // Version is the current pr9k release version.
-const Version = "0.8.0"
+const Version = "0.8.1"

--- a/workflow/prompts/feature-work.md
+++ b/workflow/prompts/feature-work.md
@@ -12,9 +12,14 @@ Implement github issue #{{ISSUE_ID}} in the current branch (do not switch branch
 
 If there are no image attachments on github issue #{{ISSUE_ID}}, skip to the TDD self-healing loop.
 
-Download all images attached to the github issue
-- Save images to .pr9k/artifacts/ui-designs/
-- Use appropriate images as visual reference for UI development
+Download all images attached to the github issue, save them to `.pr9k/artifacts/ui-designs/`, then prepare a processed set the vision API will accept:
+
+- Skip animated GIFs and non-raster formats (`.svg`, `.heic`, `.bmp`, etc.).
+- For each remaining image, write a processed copy under `.pr9k/artifacts/ui-designs/processed/`:
+  - If the file is already PNG or JPEG and is at most 1568 px on its longest edge and at most ~1 MB on disk, copy it as-is.
+  - Otherwise, re-encode/downscale to JPEG or PNG, capped at 1568 px on the longest edge and roughly 1 MB on disk. `sips` (macOS) or `ffmpeg` is available in the sandbox.
+- Reference only the processed copies as visual references for UI development.
+- If reading any single processed image still fails (e.g. the vision API returns "Could not process image"), log the filename and skip that image — do not retry the same image, and do not abort the step.
 
 ## TDD self-healing loop
 


### PR DESCRIPTION
## Summary

**This PR fixes three independent UI/sandbox annoyances in the run-mode TUI and claude sandbox so that resizing the terminal, starting any claude step, and feeding issue images into vision-API steps all stop misbehaving.**

- Run-mode TUI now survives terminal zoom/resize: `WindowSizeMsg` issues `tea.ClearScreen` to wipe stale alt-screen rows, and `View()` returns a "Terminal too small — resize to at least 60×N" placeholder when the terminal can't fit the chrome (where N is computed from the configured grid rows). Mouse events are ignored in placeholder mode.
- `--init` is removed from all three `docker run` argv builders (`BuildRunArgs`, `BuildInteractiveArgs`, `BuildShellArgs`). The image's existing `tini --` ENTRYPOINT now runs as PID 1 with no behavior change, eliminating the `Tini is not running as PID 1` WARN that printed to stderr on every claude step.
- `workflow/prompts/feature-work.md` now instructs the agent to pre-process attached issue images into a `.pr9k/artifacts/ui-designs/processed/` set (PNG/JPEG, ≤ 1568 px longest edge, ~1 MB) and skip animated GIFs / non-raster formats, so the vision API stops rejecting attachments with "Could not process image".
- Version bumped `0.8.0` → `0.8.1` (patch — bug fixes only, no CLI/`config.json` schema changes).

### Behavior changes

| Surface | Before | After |
|---|---|---|
| Run-mode TUI on resize | Top border vanished; grid rows appeared shuffled after zoom (alt-screen scrolled, renderer kept stale cursor) | Alt-screen is fully cleared on every `WindowSizeMsg`; grid renders cleanly |
| Run-mode TUI when terminal is below `60 × (chromeRows+1)` | Over-tall frame, top clipped | Single-line "Terminal too small — resize to at least 60×N" placeholder; mouse events ignored |
| Every claude step / `pr9k sandbox -i` / `pr9k sandbox shell` | 3-line tini WARN on stderr at start of every step | Silent; image's tini runs as PID 1 |
| `feature-work` prompt with issue images | Vision API rejected animated GIFs, oversized images, and uncommon formats | Pre-processed copies are referenced; unsupported formats are skipped |

## What to look at first

- `src/internal/ui/model.go` — the new `tooSmall()` / `minHeight()` helpers and the `tea.ClearScreen` cmd added to the `WindowSizeMsg` batch. `minHeight` is computed from `gridRows` (not the static `uichrome.MinTerminalHeight=16`) because workflows with many steps need a taller minimum.
- `src/internal/sandbox/command.go` — three `--init` removals plus the inline comment explaining why. Termination semantics are preserved because `terminator.go` uses `docker kill <cid>` and is PID-1-agnostic on the host side; both Docker's tini and the image's tini have equivalent SIGTERM-forwarding/zombie-reaping behavior.
- `docs/plans/run-tui-resize-overflow.md` and `docs/plans/sandbox-tini-warning.md` — the evidence-based investigations behind the two fixes, including the renderer-level root cause for the resize bug (Bubble Tea's `repaint()` does not erase the alt-screen on resize).
- `workflow/prompts/feature-work.md` — the new processed-images contract. Note the explicit "log filename and skip" rule for images that still fail after processing, so a single bad attachment does not abort the whole step.

## How this was tested

- ✅ Added `TestView_FrameNeverExceedsHeight` (table-driven over 8 width/height/step combinations) asserting `len(View()) <= m.height`.
- ✅ Added `TestView_TooSmall_RendersPlaceholder` asserting placeholder string and absence of border glyphs.
- ✅ Added `TestView_AfterResizeSmallThenLarge_RendersFullFrame` covering small→large resize transitions.
- ✅ Added `TestWindowSizeMsg_ReturnsClearScreenCmd` regression guard for the alt-screen clear.
- ✅ Added `TestMouseMsg_TooSmall_Ignored` ensuring mouse coordinate translation does not run against the placeholder.
- ✅ Added `TestBuildRunArgs_NoDoubleInit`, `TestBuildInteractiveArgs_NoDoubleInit`, `TestBuildShellArgs_NoDoubleInit` regression tests so re-introducing `--init` in any one builder fails CI.
- ✅ Updated existing assertions in `command_test.go`, `sandbox_interactive_test.go`, `sandbox_shell_test.go` to match the new argv shape.
- ✅ Adjusted `TestView_StatusLine_NarrowTerminal_TruncatesStatusText` to use width=60 (the new minimum); below that, `View()` short-circuits to the placeholder.
- ⚠️ The renderer-level alt-screen artifact cannot be unit-tested without a full Bubble Tea program — the cmd-contract test is the strongest model-level guarantee. Manual verification protocol is documented in `docs/plans/run-tui-resize-overflow.md` (zoom in, zoom out, observe re-render).

## Files of interest

- `src/internal/ui/model.go` — `tooSmall`/`minHeight` helpers, `tea.ClearScreen` on `WindowSizeMsg`, mouse short-circuit, `View()` placeholder branch.
- `src/internal/sandbox/command.go` — removes `--init` from all three argv builders with inline rationale.
- `src/internal/ui/model_test.go` — five new resize/overflow tests including the cmd-contract regression guard.
- `workflow/prompts/feature-work.md` — vision-API image pre-processing contract for issue attachments.
- `docs/plans/run-tui-resize-overflow.md` — root-cause analysis distinguishing renderer stale-cursor (primary) vs. min-size overflow (secondary).

## Test scenario changes

- New: a too-small terminal (height below `chromeRows + 1`) renders only the placeholder, never partial chrome.
- New: a `WindowSizeMsg` always returns a batch containing `tea.ClearScreen`, regardless of whether the new size is renderable.
- New: a mouse left-press while in placeholder mode is a no-op and does not enter `ModeSelect`.
- New: resizing from small (placeholder) up to large renders the full chrome on the next `View()` call.
- New: none of the three docker argv builders include `--init` (regression guard for the tini WARN fix).